### PR TITLE
Ensure word boundary for ELIF token

### DIFF
--- a/core/lexer.py
+++ b/core/lexer.py
@@ -73,7 +73,7 @@ def tokenize(code) -> tuple[list[Token], dict[str, str]]:
 
         # Keywords
         ('IF',        r'\bif\b'),
-        ('ELIF',      r'\belif'),
+        ('ELIF',      r'\belif\b'),
         ('ELSE',      r'\belse\b'),
         ('WHILE',     r'\bloop\b'),
         ('BREAK',     r'\bbreak\b'),


### PR DESCRIPTION
## Summary
- restrict ELIF token regex to match only the standalone keyword

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_688f3d2066b88323a575cacdb3796eac