### PR TITLE
Refactor function-call statements into generic expression statements

### DIFF
--- a/core/interpreter.py
+++ b/core/interpreter.py
@@ -453,14 +453,15 @@ class Interpreter:
                 self.functions[name] = (params, body)
 
 
-            elif kind == 'func_call':
-                self.eval_expr(stmt)
-
-
             elif kind == 'return':
                 _, expr_node, _ = stmt
                 value = self.eval_expr(expr_node)
                 raise ReturnControlFlow(value)
+
+
+            elif kind == 'expr_stmt':
+                _, expr_node, _ = stmt
+                self.eval_expr(expr_node)
 
 
             else:

--- a/core/parser.py
+++ b/core/parser.py
@@ -371,7 +371,8 @@ class Parser:
             if (self._position + 1 < len(self._tokens)
                     and self._tokens[self._position + 1].type == 'ASSIGN'):
                 return self._parse_reassignment()
-            return self._parse_func_call_or_error()
+            expr_node = self._factor()
+            return ('expr_stmt', expr_node, expr_node[-1])
         elif tok.type == 'RETURN':
             return self._parse_return()
         else:
@@ -534,40 +535,6 @@ class Parser:
         self._eat('RPAREN')
         body = self._block()
         return ('func_def', func_name, params, body, start_tok.line)
-
-
-    def _parse_func_call_or_error(self) -> tuple:
-        """
-        Parse a function call or raise a syntax error.
-
-        Syntax:
-            <identifier>(<arg1>, <arg2>, ...)
-
-        Returns:
-            tuple: ('func_call', function_name, [arg_exprs], line_number)
-
-        Raises:
-            SyntaxError: If the call syntax is invalid or unexpected tokens follow.
-        """
-        tok = self._current_token
-        func_name = tok.value
-        self._eat('ID')
-        if self._current_token.type == 'LPAREN':
-            self._eat('LPAREN')
-            args = []
-            if self._current_token.type != 'RPAREN':
-                args.append(self._expr())  # parse an expression argument
-                while self._current_token.type == 'COMMA':
-                    self._eat('COMMA')
-                    args.append(self._expr())
-            self._eat('RPAREN')
-            return ('func_call', func_name, args, tok.line)
-        else:
-            # Could be a variable usage statement or error if not expected
-            raise SyntaxError(
-                f"Unexpected token '{tok.value}' after identifier {func_name} "
-                f"on line {tok.line} in {self._source_file}"
-            )
 
 
     def _parse_return(self) -> tuple:

--- a/tests/test_function_calls.py
+++ b/tests/test_function_calls.py
@@ -1,0 +1,44 @@
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from core.lexer import tokenize, Token
+from core.parser import Parser
+from core.interpreter import Interpreter
+
+
+def parse_source(source: str):
+    tokens, token_map = tokenize(source)
+    eof_line = tokens[-1].line if tokens else 1
+    tokens.append(Token('EOF', None, eof_line))
+    parser = Parser(tokens, token_map, '<test>')
+    return parser.parse()
+
+
+def test_call_ast_and_runtime(capsys):
+    source = (
+        "proc foo() { emit 42 }\n"
+        "foo()\n"
+        "emit foo()\n"
+    )
+    ast = parse_source(source)
+
+    # The standalone call should be wrapped in an expr_stmt
+    expr_stmt = ast[1]
+    emit_stmt = ast[2]
+
+    assert expr_stmt[0] == 'expr_stmt'
+    assert emit_stmt[0] == 'emit'
+    # The function call expressions should match (ignoring line numbers)
+    call1 = expr_stmt[1]
+    call2 = emit_stmt[1]
+    assert call1[0] == 'func_call'
+    assert call2[0] == 'func_call'
+    assert call1[:3] == call2[:3]
+
+    interpreter = Interpreter('<test>')
+    interpreter.execute(ast)
+    captured = capsys.readouterr().out.strip().splitlines()
+    assert captured == ['42', '42', 'None']
+


### PR DESCRIPTION
## Summary
- Treat standalone function calls as generic expression statements parsed via `_factor`
- Simplify interpreter by evaluating `'expr_stmt'` nodes instead of special `'func_call'` statements
- Add tests ensuring inline and standalone function calls share the same AST shape and runtime effects

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688f42a1fe788323a331c2f4d39cdd4e