### PR TITLE
Add logical AND to OMG conditionals

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -91,6 +91,7 @@ The lexer scans the raw text and splits it into a stream of tokens. Each token h
     * Assignment: `:=`
     * Output: `<<`
     * Bitwise: `&`, `|`, `^`, `~`, `<<`, `>>`
+    * Logical: `and`
 * **Identifiers**: variable and function names.
 * **Literals**: integers and strings.
 * **Punctuation**: `(`, `)`, `{`, `}`, `[`, `]`, `,`, `:`.
@@ -113,6 +114,7 @@ The parser is a hand‑written **recursive descent parser** following an LL(1) g
 | 6     | **Bitwise XOR**    | `^`                        | `_bitwise_xor`  |
 | 7     | **Bitwise OR**     | `\|`                        | `_bitwise_or`   |
 | 8     | **Comparison**     | `==`, `!=`, `<`, `>`, `<=`, `>=` | `_comparison`   |
+| 9     | **Logical AND**    | `and`                      | `_logical_and`  |
 
 Each layer wraps the tighter-binding expressions from below, ensuring proper operator grouping. This model gives OMG clear operator precedence semantics.
 
@@ -133,9 +135,11 @@ Each layer wraps the tighter-binding expressions from below, ensuring proper ope
 
 * `_bitwise_or()` – handles `|`.
 
-* `_expr()` – entry point for expression parsing.
-
 * `_comparison()` – handles relational comparisons.
+
+* `_logical_and()` – handles `and`.
+
+* `_expr()` – entry point for expression parsing.
 
 * `_statement()` – parses assignments, output, control flow, etc.
 

--- a/core/interpreter.py
+++ b/core/interpreter.py
@@ -227,6 +227,7 @@ class Interpreter:
                 Op.LT,
                 Op.GE,
                 Op.LE,
+                Op.AND,
             ):
                 lhs = self.eval_expr(node[1])
                 rhs = self.eval_expr(node[2])
@@ -269,6 +270,8 @@ class Interpreter:
                         term = lhs >= rhs
                     case Op.LE:
                         term = lhs <= rhs
+                    case Op.AND:
+                        term = bool(lhs) and bool(rhs)
                     case _:
                         raise UnknownOpException(
                             f"Unknown binary operator '{op}'"

--- a/core/lexer.py
+++ b/core/lexer.py
@@ -81,6 +81,7 @@ def tokenize(code) -> tuple[list[Token], dict[str, str]]:
         ('FACTS',     r'\bfacts\b'),
         ('FUNC',      r'\bproc\b'),
         ('RETURN',    r'\breturn\b'),
+        ('AND',       r'\band\b'),
 
         # Chain
         # ('CHAIN',     r''),

--- a/core/operations.py
+++ b/core/operations.py
@@ -37,6 +37,9 @@ class Op(str, Enum):
     # Unary bitwise
     NOT_BITS = "not_bits"
 
+    # Boolean
+    AND = "and"
+
     def __str__(self) -> str:  # pragma: no cover - trivial
         """Return the underlying string value for nicer debug output."""
         return self.value

--- a/core/parser/parser.py
+++ b/core/parser/parser.py
@@ -70,23 +70,11 @@ class Parser:
         """
         return _expr.parse_term(self)
 
-    def bitwise_or(self) -> tuple:
+    def add_sub(self) -> tuple:
         """
-        Parse a bitwise OR expression.
+        Parse an addition or subtraction expression.
         """
-        return _expr.parse_bitwise_or(self)
-
-    def bitwise_xor(self) -> tuple:
-        """
-        Parse a bitwise XOR expression.
-        """
-        return _expr.parse_bitwise_xor(self)
-
-    def bitwise_and(self) -> tuple:
-        """
-        Parse a bitwise AND expression.
-        """
-        return _expr.parse_bitwise_and(self)
+        return _expr.parse_add_sub(self)
 
     def shift(self) -> tuple:
         """
@@ -94,23 +82,41 @@ class Parser:
         """
         return _expr.parse_shift(self)
 
-    def add_sub(self) -> tuple:
+    def bitwise_and(self) -> tuple:
         """
-        Parse an addition or subtraction expression.
+        Parse a bitwise AND expression.
         """
-        return _expr.parse_add_sub(self)
+        return _expr.parse_bitwise_and(self)
 
-    def expr(self) -> tuple:
+    def bitwise_xor(self) -> tuple:
         """
-        Parse a full expression with arithmetic or logical operations.
+        Parse a bitwise XOR expression.
         """
-        return _expr.parse_expr(self)
+        return _expr.parse_bitwise_xor(self)
+
+    def bitwise_or(self) -> tuple:
+        """
+        Parse a bitwise OR expression.
+        """
+        return _expr.parse_bitwise_or(self)
 
     def comparison(self) -> tuple:
         """
         Parse a comparison expression using relational operators.
         """
         return _expr.parse_comparison(self)
+
+    def logical_and(self) -> tuple:
+        """
+        Parse a logical AND expression.
+        """
+        return _expr.parse_logical_and(self)
+
+    def expr(self) -> tuple:
+        """
+        Parse a full expression with arithmetic or logical operations.
+        """
+        return _expr.parse_expr(self)
 
 
     # Statement wrappers

--- a/core/parser/statements.py
+++ b/core/parser/statements.py
@@ -93,7 +93,7 @@ def parse_facts(parser: 'Parser') -> tuple:
     """
     tok = parser.curr_token
     parser.eat("FACTS")
-    expr_node = parser.comparison()
+    expr_node = parser.expr()
     return ("facts", expr_node, tok.line)
 
 
@@ -128,13 +128,13 @@ def parse_if(parser: 'Parser') -> tuple:
     """
     tok = parser.curr_token
     parser.eat("IF")
-    condition = parser.comparison()
+    condition = parser.expr()
     then_block = parser.block()
 
     elif_cases = []
     while parser.curr_token.type == 'ELIF':
         parser.eat('ELIF')
-        cond = parser.comparison()
+        cond = parser.expr()
         block = parser.block()
         elif_cases.append((cond, block))
 
@@ -160,7 +160,7 @@ def parse_while(parser: 'Parser') -> tuple:
     """
     tok = parser.curr_token
     parser.eat('WHILE')
-    condition = parser.comparison()
+    condition = parser.expr()
     body = parser.block()
     return ('loop', condition, body, tok.line)
 

--- a/tests/test_and_conditionals.py
+++ b/tests/test_and_conditionals.py
@@ -1,0 +1,64 @@
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from core.lexer import tokenize, Token
+from core.parser import Parser
+from core.operations import Op
+from core.interpreter import Interpreter
+
+
+def parse_source(source: str):
+    tokens, token_map = tokenize(source)
+    eof_line = tokens[-1].line if tokens else 1
+    tokens.append(Token('EOF', None, eof_line))
+    parser = Parser(tokens, token_map, '<test>')
+    return parser.parse()
+
+
+def test_if_and_ast_and_runtime(capsys):
+    source = (
+        "alloc a := true\n"
+        "alloc b := true\n"
+        "if a and b { emit 1 }\n"
+    )
+    ast = parse_source(source)
+    if_stmt = ast[2]
+    cond = if_stmt[1]
+    assert cond[0] == Op.AND
+    interpreter = Interpreter('<test>')
+    interpreter.execute(ast)
+    captured = capsys.readouterr().out.strip().splitlines()
+    assert captured == ['1']
+
+
+def test_elif_and_runtime(capsys):
+    source = (
+        "alloc a := true\n"
+        "alloc b := false\n"
+        "alloc c := true\n"
+        "if a and b { emit 1 } elif a and c { emit 2 }\n"
+    )
+    ast = parse_source(source)
+    interpreter = Interpreter('<test>')
+    interpreter.execute(ast)
+    captured = capsys.readouterr().out.strip().splitlines()
+    assert captured == ['2']
+
+
+def test_comparison_and_precedence(capsys):
+    source = (
+        "alloc a := 1\n"
+        "alloc b := 2\n"
+        "if a == 1 and b == 2 { emit 1 }\n"
+    )
+    ast = parse_source(source)
+    cond = ast[2][1]
+    assert cond[0] == Op.AND
+    assert cond[1][0] == Op.EQ
+    assert cond[2][0] == Op.EQ
+    interpreter = Interpreter('<test>')
+    interpreter.execute(ast)
+    captured = capsys.readouterr().out.strip().splitlines()
+    assert captured == ['1']


### PR DESCRIPTION
## Summary
- add `and` keyword token and Boolean op
- parse and evaluate logical `and` expressions
- document and test `and` in if/elif conditionals
- ensure comparison operators have higher precedence than logical `and`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689087d1fc388323baf4bd53245edbcb