### PR TITLE
Add unary plus and minus operations

### DIFF
--- a/core/interpreter.py
+++ b/core/interpreter.py
@@ -291,6 +291,22 @@ class Interpreter:
                                 f"On line {line} in {self.file}"
                             )
                         return ~operand
+                    case Op.ADD:
+                        if not isinstance(operand, int):
+                            raise TypeError(
+                                f"Unary plus (+) requires a numeric operand "
+                                f"{self._format_expr(node)}\n"
+                                f"On line {line} in {self.file}"
+                            )
+                        return +operand
+                    case Op.SUB:
+                        if not isinstance(operand, int):
+                            raise TypeError(
+                                f"Unary minus (-) requires a numeric operand "
+                                f"{self._format_expr(node)}\n"
+                                f"On line {line} in {self.file}"
+                            )
+                        return -operand
                     case _:
                         raise UnknownOpException(
                             f"Unknown unary operator '{operator}'!"

--- a/core/parser/expressions.py
+++ b/core/parser/expressions.py
@@ -23,6 +23,14 @@ def parse_factor(parser: 'Parser') -> tuple:
         operand = parser.factor()
         return ('unary', Op.NOT_BITS, operand, tok.line)
 
+    if tok.type in ('PLUS', 'MINUS'):
+        parser.eat(tok.type)
+        op_map = {
+            'PLUS': Op.ADD,
+            'MINUS': Op.SUB,
+        }
+        return ('unary', op_map[tok.type], parser.factor(), tok.line)
+
     if tok.type == 'NUMBER':
         parser.eat('NUMBER')
         return ('number', tok.value, tok.line)

--- a/tests/test_unary_ops.py
+++ b/tests/test_unary_ops.py
@@ -1,0 +1,41 @@
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from core.lexer import tokenize, Token
+from core.parser import Parser
+from core.operations import Op
+from core.interpreter import Interpreter
+
+
+def parse_source(source: str):
+    tokens, token_map = tokenize(source)
+    eof_line = tokens[-1].line if tokens else 1
+    tokens.append(Token('EOF', None, eof_line))
+    parser = Parser(tokens, token_map, '<test>')
+    return parser.parse()
+
+
+def test_unary_ops_parse_and_runtime(capsys):
+    source = (
+        "emit -5\n"
+        "emit +5\n"
+        "alloc a := 2\n"
+        "emit -a\n"
+        "emit +a\n"
+    )
+    ast = parse_source(source)
+
+    emit_neg = ast[0]
+    emit_pos = ast[1]
+
+    assert emit_neg[1][0] == 'unary'
+    assert emit_neg[1][1] == Op.SUB
+    assert emit_pos[1][0] == 'unary'
+    assert emit_pos[1][1] == Op.ADD
+
+    interpreter = Interpreter('<test>')
+    interpreter.execute(ast)
+    captured = capsys.readouterr().out.strip().splitlines()
+    assert captured == ['-5', '5', '-2', '2']


### PR DESCRIPTION
## Summary
- allow parser to create unary nodes for leading `+` and `-`
- interpret unary plus (no-op) and unary minus (numeric negation)
- test negative literals and unary expressions

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6890bbb3f3d88323a3baf2b49ffc1cba