### PR TITLE
Distinguish declarations from assignments

### DIFF
--- a/core/interpreter.py
+++ b/core/interpreter.py
@@ -407,7 +407,7 @@ class Interpreter:
 
         Parameters:
             statements (list):
-                A list of ('assign' | 'emit' | 'if' | 'block' | 'loop', ...) tuples.
+                A list of ('decl' | 'assign' | 'emit' | 'if' | 'block' | 'loop', ...) tuples.
 
         Raises:
             Exception: For unknown statement types.
@@ -417,8 +417,19 @@ class Interpreter:
             line = stmt[-1]
 
 
-            if kind == 'assign':
+            if kind == 'decl':
                 _, var_name, expr_node, _ = stmt
+                if var_name in self.vars:
+                    raise RuntimeError(
+                        f"Variable '{var_name}' already declared on line {line} in {self.file}"
+                    )
+                value = self.eval_expr(expr_node)
+                self.vars[var_name] = value
+
+            elif kind == 'assign':
+                _, var_name, expr_node, _ = stmt
+                if var_name not in self.vars:
+                    raise UndefinedVariableException(var_name, line, self.file)
                 value = self.eval_expr(expr_node)
                 self.vars[var_name] = value
 

--- a/core/parser/parser.py
+++ b/core/parser/parser.py
@@ -180,11 +180,11 @@ class Parser:
         """
         return _stmt.parse_reassignment(self)
 
-    def parse_assignment(self) -> tuple:
+    def parse_declaration(self) -> tuple:
         """
-        Parse a new variable assignment statement.
+        Parse a new variable declaration statement.
         """
-        return _stmt.parse_assignment(self)
+        return _stmt.parse_declaration(self)
 
 
     def parse(self):

--- a/core/parser/statements.py
+++ b/core/parser/statements.py
@@ -59,7 +59,7 @@ def parse_statement(parser: 'Parser') -> tuple:
     elif tok.type == 'FUNC':
         return parser.parse_func_def()
     elif tok.type == 'ALLOC':
-        return parser.parse_assignment()
+        return parser.parse_declaration()
     elif tok.type == 'ID':
         if (
             parser.position + 1 < len(parser.tokens)
@@ -241,15 +241,15 @@ def parse_reassignment(parser: 'Parser') -> tuple:
     return ('assign', id_tok.value, expr_node, id_tok.line)
 
 
-def parse_assignment(parser: 'Parser') -> tuple:
+def parse_declaration(parser: 'Parser') -> tuple:
     """
-    Parse an 'alloc' variable assignment.
-    
+    Parse an ``alloc`` variable declaration.
+
     Args:
         parser: The parser instance.
 
     Returns:
-        tuple: representing the AST node.
+        tuple: ('decl', name, expr, line)
     """
     parser.eat('ALLOC')
     id_tok = parser.curr_token
@@ -268,4 +268,4 @@ def parse_assignment(parser: 'Parser') -> tuple:
         )
     parser.eat('ASSIGN')
     expr_node = parser.expr()
-    return ('assign', var_name, expr_node, id_tok.line)
+    return ('decl', var_name, expr_node, id_tok.line)

--- a/tests/test_declaration_assignment.py
+++ b/tests/test_declaration_assignment.py
@@ -1,0 +1,44 @@
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from core.lexer import tokenize, Token
+from core.parser import Parser
+from core.interpreter import Interpreter
+from core.exceptions import UndefinedVariableException
+
+
+def parse_source(source: str):
+    tokens, token_map = tokenize(source)
+    eof_line = tokens[-1].line if tokens else 1
+    tokens.append(Token('EOF', None, eof_line))
+    parser = Parser(tokens, token_map, '<test>')
+    return parser.parse()
+
+
+def test_decl_and_assign_ast_and_runtime():
+    source = (
+        "alloc x := 5\n"
+        "x := x + 1\n"
+    )
+    ast = parse_source(source)
+    decl, assign = ast
+    assert decl[0] == 'decl'
+    assert assign[0] == 'assign'
+
+    interpreter = Interpreter('<test>')
+    interpreter.execute(ast)
+    assert interpreter.vars['x'] == 6
+
+
+def test_assign_without_decl_raises():
+    source = "x := 5\n"
+    ast = parse_source(source)
+    interpreter = Interpreter('<test>')
+    try:
+        interpreter.execute(ast)
+    except UndefinedVariableException:
+        pass
+    else:
+        raise AssertionError('expected UndefinedVariableException')


### PR DESCRIPTION
## Summary
- Add `decl` AST node for `alloc` and keep `assign` for reassignment
- Enforce declaration vs reassignment semantics in interpreter
- Test new declaration and assignment behavior

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6890c4a4209c8323ab948451415d0e60