### PR TITLE
Implement lexical scoping for procedure calls

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -151,7 +151,7 @@ Handled by `execute(statements)`. Supported statements include:
 
 * **return** – return a value from a function.
 
-Each function call creates a new scope for its parameters, and the previous variable state is restored afterward (there are no closures or first‑class functions yet).
+Each function call creates a fresh scope seeded with global variables and its parameters. Locals from the caller are not visible, and the previous variable state is restored afterward (there are no closures or first‑class functions yet).
 
 ## Example
 
@@ -203,7 +203,7 @@ emit "Finished loop."
 ## Design Notes
 
 * **Header requirement** – scripts must begin with `;;;omg` to be valid.
-* **Scope model** – variables are global except during function calls, which create a local scope.
+* **Scope model** – variables are global except during function calls, which create a local scope with access only to globals and parameters.
 - **Operator precedence** – enforced explicitly in the parser via method hierarchy.
 * **Error handling** – line numbers and file names are preserved for better error messages.
 * **Extensibility** – new constructs can be added by expanding the parser and interpreter.

--- a/core/interpreter.py
+++ b/core/interpreter.py
@@ -52,6 +52,7 @@ class Interpreter:
         Initialize the interpreter.
         """
         self.vars = {}
+        self.global_vars = self.vars
         self.functions = {}
         self.file = file
 
@@ -383,7 +384,8 @@ class Interpreter:
                         f"On line {line} in {self.file}"
                     )
 
-                saved_vars = self.vars.copy()
+                saved_vars = self.vars
+                self.vars = self.global_vars.copy()
                 self.vars.update(dict(zip(params, args)))
 
                 try:

--- a/examples/permissions.omg
+++ b/examples/permissions.omg
@@ -43,8 +43,9 @@ proc permissions(mode) {
 alloc codes := [755, 644, 700, 600, 777]
 alloc i := 0
 
+alloc mode := 0
 loop i < length(codes) {
-    alloc mode := codes[i]
+    mode := codes[i]
     emit mode + ": " + permissions(mode)
     i := i + 1
 }

--- a/examples/rot-13.omg
+++ b/examples/rot-13.omg
@@ -5,8 +5,9 @@ proc shift(a_list, n) {
     alloc i := 0
     alloc result := []
     alloc len := length(a_list)
+    alloc shifted := []
     loop i < len {
-        alloc shifted := a_list[(i + n) % len]
+        shifted := a_list[(i + n) % len]
         result := result + [shifted]
         i := i + 1
     }
@@ -41,17 +42,23 @@ proc rot13(input) {
     alloc base := alphabet()
     alloc table := tabula_recta()
     alloc i := 0
+    alloc j := 0
+    alloc k  := 0
+    alloc char   := 0
+    alloc found  := false
     alloc result := ""
+    alloc rot    := ""
+
     loop i < length(input) {
-        alloc c := input[i]
-        alloc j := 0
-        alloc found := false
-        alloc index := 0
+        char := input[i]
+        j := 0
+        k := 0
+        found := false
 
         loop j < length(base) {
-            if base[j] == c {
+            if base[j] == char {
                 found := true
-                index := j
+                k := j
                 j := length(base)
             } else {
                 j := j + 1
@@ -59,8 +66,8 @@ proc rot13(input) {
         }
 
         if found {
-            alloc rot := table[13]
-            result := result + rot[index]
+            rot := table[13]
+            result := result + rot[k]
         } else {
             result := result + c
         }

--- a/examples/tabula-recta.omg
+++ b/examples/tabula-recta.omg
@@ -16,8 +16,9 @@ proc shift(a_list, n) {
     alloc i := 0
     alloc result := []
     alloc len := length(a_list)
+    alloc shifted := []
     loop i < len {
-        alloc shifted := a_list[(i + n) % len]
+        shifted := a_list[(i + n) % len]
         result := result + [shifted]
         i := i + 1
     }

--- a/tests/test_scoping.py
+++ b/tests/test_scoping.py
@@ -1,0 +1,47 @@
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from core.lexer import tokenize, Token
+from core.parser import Parser
+from core.interpreter import Interpreter
+
+def parse_source(source: str):
+    tokens, token_map = tokenize(source)
+    eof_line = tokens[-1].line if tokens else 1
+    tokens.append(Token('EOF', None, eof_line))
+    parser = Parser(tokens, token_map, '<test>')
+    return parser.parse()
+
+def test_functions_have_fresh_env(capsys):
+    source = (
+        "proc inner() {\n"
+        "    alloc x := 1\n"
+        "    return x\n"
+        "}\n"
+        "proc outer() {\n"
+        "    alloc x := 2\n"
+        "    return inner()\n"
+        "}\n"
+        "emit outer()\n"
+    )
+    ast = parse_source(source)
+    interpreter = Interpreter('<test>')
+    interpreter.execute(ast)
+    captured = capsys.readouterr().out.strip().splitlines()
+    assert captured == ['1']
+
+def test_globals_visible(capsys):
+    source = (
+        "alloc g := 5\n"
+        "proc read_g() {\n"
+        "    return g\n"
+        "}\n"
+        "emit read_g()\n"
+    )
+    ast = parse_source(source)
+    interpreter = Interpreter('<test>')
+    interpreter.execute(ast)
+    captured = capsys.readouterr().out.strip().splitlines()
+    assert captured == ['5']


### PR DESCRIPTION
## Summary
- Give each procedure call a fresh local environment seeded only with globals
- Document the scope rules in README
- Add regression tests ensuring functions don't share caller locals and can read globals

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6891116cfe348323b9e7a4c26ea2b71a