### PR TITLE
Fix logical and short-circuit semantics

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -140,8 +140,7 @@ the form `(operation, operands…, line)`.
 | 7     | **Bitwise OR**     | `\|`                        | `_bitwise_or`   |
 | 8     | **Comparison**     | `==`, `!=`, `<`, `>`, `<=`, `>=` | `_comparison`   |
 | 9     | **Logical AND**    | `and`                      | `_logical_and`  |
-
-Each layer wraps the tighter-binding expressions from below, ensuring proper operator grouping. This model gives OMG clear operator precedence semantics.
+Logical AND is left-associative and evaluates with short-circuit semantics, so a chain like `a and b and c` is parsed as `(a and b) and c` and produces a boolean result. Each layer wraps the tighter-binding expressions from below, ensuring proper operator grouping. This model gives OMG clear operator precedence semantics.
 
 Each AST node is represented as a tuple encoding the operation, its operands and the originating line number. For example:
 
@@ -169,6 +168,7 @@ Unary operators include `+`, `-`, and `~`. Built‑in functions such as
 `chr`, `ascii`, `hex`, `binary`, and `length` are dispatched directly, while
 user‑defined procedures evaluate arguments, bind parameters, execute the body
 and return the resulting value (or `None` if no `return` is encountered).
+Logical `and` short‑circuits: the right‑hand side is evaluated only if the left‑hand side is truthy, and the operator always produces a boolean value.
 
 ### Statement Execution
 

--- a/core/interpreter.py
+++ b/core/interpreter.py
@@ -237,6 +237,11 @@ class Interpreter:
                 Op.AND,
             ):
                 lhs = self.eval_expr(node[1])
+                if op == Op.AND:
+                    if not bool(lhs):
+                        return False
+                    rhs = self.eval_expr(node[2])
+                    return bool(rhs)
                 rhs = self.eval_expr(node[2])
                 match op:
                     # Arithmetic
@@ -277,8 +282,6 @@ class Interpreter:
                         term = lhs >= rhs
                     case Op.LE:
                         term = lhs <= rhs
-                    case Op.AND:
-                        term = bool(lhs) and bool(rhs)
                     case _:
                         raise UnknownOpException(
                             f"Unknown binary operator '{op}'"

--- a/tests/test_and_conditionals.py
+++ b/tests/test_and_conditionals.py
@@ -62,3 +62,19 @@ def test_comparison_and_precedence(capsys):
     interpreter.execute(ast)
     captured = capsys.readouterr().out.strip().splitlines()
     assert captured == ['1']
+
+
+def test_and_short_circuits(capsys):
+    source = (
+        "proc rhs() {\n"
+        "    emit \"rhs\"\n"
+        "    return true\n"
+        "}\n"
+        "if false and rhs() { emit \"bad\" } else { emit \"ok\" }\n"
+        "if false and (1 / 0) { emit \"bad\" } else { emit \"ok\" }\n"
+    )
+    ast = parse_source(source)
+    interpreter = Interpreter('<test>')
+    interpreter.execute(ast)
+    captured = capsys.readouterr().out.strip().splitlines()
+    assert captured == ['ok', 'ok']


### PR DESCRIPTION
## Summary
- ensure logical `and` evaluates the right-hand side only when the left-hand side is truthy
- document that `and` is left-associative, short-circuits, and always returns a boolean
- cover short-circuit behavior with new tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68912b671bbc8323be737a171bcbb594