### PR TITLE
Use integer division in VM examples

### DIFF
--- a/examples/5.omg
+++ b/examples/5.omg
@@ -119,11 +119,11 @@ loop ptr < length(program) {
         stack := stack[0:length(stack) - 1]
         stack := stack + [lhs * rhs]
     } elif op == "div" {
-        rhs := stack[length(stack) - 1]
+        alloc a := stack[length(stack) - 1]
         stack := stack[0:length(stack) - 1]
-        lhs := stack[length(stack) - 1]
+        alloc b := stack[length(stack) - 1]
         stack := stack[0:length(stack) - 1]
-        stack := stack + [lhs / rhs]
+        stack := stack + [b // a]
     } elif op == "store" {
         val := stack[length(stack) - 1]
         stack := stack[0:length(stack) - 1]

--- a/examples/stack-based-vm.omg
+++ b/examples/stack-based-vm.omg
@@ -127,7 +127,7 @@ loop ptr < length(program) {
         stack := stack[0:length(stack) - 1]
         lhs := stack[length(stack) - 1]
         stack := stack[0:length(stack) - 1]
-        stack := stack + [lhs / rhs]
+        stack := stack + [lhs // rhs]
     } elif op == "store" {
         val := stack[length(stack) - 1]
         stack := stack[0:length(stack) - 1]


### PR DESCRIPTION
## Summary
- ensure VM example divides with integer semantics
- update stack-based VM example to mirror integer division change

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689147f037208323a872ad47fb083902