### PR TITLE
Add short-circuiting logical or operator

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -99,7 +99,7 @@ Token categories include:
     * Comparison: `==`, `!=`, `<`, `>`, `<=`, `>=`
     * Assignment: `:=`
     * Bitwise: `&`, `|`, `^`, `~`, `<<`, `>>`
-    * Logical: `and`
+    * Logical: `and`, `or`
 * **Identifiers** for variable and function names.
 * **Literals**: decimal integers, binary integers (e.g. `0b1010`), strings
   with escape sequences, and the boolean literals `true` and `false`.
@@ -142,8 +142,9 @@ the form `(operation, operands…, line)`.
 | 7     | **Bitwise OR**     | `\|`                        | `_bitwise_or`   |
 | 8     | **Comparison**     | `==`, `!=`, `<`, `>`, `<=`, `>=` | `_comparison`   |
 | 9     | **Logical AND**    | `and`                      | `_logical_and`  |
+| 10    | **Logical OR**     | `or`                       | `_logical_or`   |
 
-Logical AND is left-associative and evaluates with short-circuit semantics, so a chain like `a and b and c` is parsed as `(a and b) and c`, and produces a boolean result.
+Logical AND and OR are left-associative and evaluate with short-circuit semantics, so chains like `a and b and c` and `a or b or c` are parsed as `(a and b) and c` and `(a or b) or c` respectively, producing boolean results.
 
 Each layer wraps the tighter-binding expressions from below, ensuring proper operator grouping. This model provides clear operator precedence semantics.
 
@@ -175,7 +176,7 @@ user‑defined procedures evaluate arguments, bind parameters, execute the body
 and return the resulting value (or `None` if no `return` is encountered).
 `binary` also supports an optional width argument for fixed-width two's
 complement formatting.
-Logical `and` short‑circuits: the right‑hand side is evaluated only if the left‑hand side is truthy, and the operator always produces a boolean value.
+Logical `and` and `or` short‑circuit: for `and`, the right‑hand side is evaluated only if the left‑hand side is truthy; for `or`, the right‑hand side is evaluated only if the left‑hand side is falsy. Both operators always produce a boolean value.
 
 ### Statement Execution
 

--- a/core/interpreter.py
+++ b/core/interpreter.py
@@ -232,11 +232,17 @@ class Interpreter:
                 Op.GE,
                 Op.LE,
                 Op.AND,
+                Op.OR,
             ):
                 lhs = self.eval_expr(node[1])
                 if op == Op.AND:
                     if not bool(lhs):
                         return False
+                    rhs = self.eval_expr(node[2])
+                    return bool(rhs)
+                elif op == Op.OR:
+                    if bool(lhs):
+                        return True
                     rhs = self.eval_expr(node[2])
                     return bool(rhs)
                 rhs = self.eval_expr(node[2])

--- a/core/lexer.py
+++ b/core/lexer.py
@@ -78,6 +78,7 @@ def tokenize(code) -> tuple[list[Token], dict[str, str]]:
         ('FUNC',      r'\bproc\b'),
         ('RETURN',    r'\breturn\b'),
         ('AND',       r'\band\b'),
+        ('OR',        r'\bor\b'),
         ('ALLOC',     r'\balloc\b'),
 
         # Chain

--- a/core/operations.py
+++ b/core/operations.py
@@ -39,6 +39,7 @@ class Op(str, Enum):
 
     # Boolean
     AND = "and"
+    OR = "or"
 
     def __str__(self) -> str:  # pragma: no cover - trivial
         """Return the underlying string value for nicer debug output."""

--- a/core/parser/expressions.py
+++ b/core/parser/expressions.py
@@ -207,8 +207,18 @@ def parse_logical_and(parser: 'Parser') -> tuple:
     return result
 
 
+def parse_logical_or(parser: 'Parser') -> tuple:
+    """Parse logical OR expressions using the 'or' keyword."""
+    result = parser.logical_and()
+    while parser.curr_token.type == 'OR':
+        tok = parser.curr_token
+        parser.eat('OR')
+        result = (Op.OR, result, parser.logical_and(), tok.line)
+    return result
+
+
 # ---- Entry point ----
 
 def parse_expr(parser: 'Parser') -> tuple:
     """Parse an expression starting from the lowest-precedence operator."""
-    return parser.logical_and()
+    return parser.logical_or()

--- a/core/parser/parser.py
+++ b/core/parser/parser.py
@@ -110,6 +110,12 @@ class Parser:
         """
         return _expr.parse_logical_and(self)
 
+    def logical_or(self) -> tuple:
+        """
+        Parse a logical OR expression.
+        """
+        return _expr.parse_logical_or(self)
+
     def expr(self) -> tuple:
         """
         Parse a full expression with arithmetic or logical operations.

--- a/tests/test_or_conditionals.py
+++ b/tests/test_or_conditionals.py
@@ -1,0 +1,97 @@
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from core.lexer import tokenize, Token
+from core.parser import Parser
+from core.operations import Op
+from core.interpreter import Interpreter
+
+
+def parse_source(source: str):
+    tokens, token_map = tokenize(source)
+    eof_line = tokens[-1].line if tokens else 1
+    tokens.append(Token('EOF', None, eof_line))
+    parser = Parser(tokens, token_map, '<test>')
+    return parser.parse()
+
+
+def test_if_or_ast_and_runtime(capsys):
+    source = (
+        "alloc a := false\n"
+        "alloc b := true\n"
+        "if a or b { emit 1 }\n"
+    )
+    ast = parse_source(source)
+    if_stmt = ast[2]
+    cond = if_stmt[1]
+    assert cond[0] == Op.OR
+    interpreter = Interpreter('<test>')
+    interpreter.execute(ast)
+    captured = capsys.readouterr().out.strip().splitlines()
+    assert captured == ['1']
+
+
+def test_elif_or_runtime(capsys):
+    source = (
+        "alloc a := false\n"
+        "alloc b := false\n"
+        "alloc c := true\n"
+        "if a or b { emit 1 } elif b or c { emit 2 }\n"
+    )
+    ast = parse_source(source)
+    interpreter = Interpreter('<test>')
+    interpreter.execute(ast)
+    captured = capsys.readouterr().out.strip().splitlines()
+    assert captured == ['2']
+
+
+def test_comparison_or_precedence(capsys):
+    source = (
+        "alloc a := 1\n"
+        "alloc b := 2\n"
+        "if a == 1 or b == 2 { emit 1 }\n"
+    )
+    ast = parse_source(source)
+    cond = ast[2][1]
+    assert cond[0] == Op.OR
+    assert cond[1][0] == Op.EQ
+    assert cond[2][0] == Op.EQ
+    interpreter = Interpreter('<test>')
+    interpreter.execute(ast)
+    captured = capsys.readouterr().out.strip().splitlines()
+    assert captured == ['1']
+
+
+def test_or_and_precedence(capsys):
+    source = (
+        "alloc a := false\n"
+        "alloc b := true\n"
+        "alloc c := true\n"
+        "if a and b or c { emit 1 }\n"
+    )
+    ast = parse_source(source)
+    cond = ast[3][1]
+    assert cond[0] == Op.OR
+    assert cond[1][0] == Op.AND
+    interpreter = Interpreter('<test>')
+    interpreter.execute(ast)
+    captured = capsys.readouterr().out.strip().splitlines()
+    assert captured == ['1']
+
+
+def test_or_short_circuits(capsys):
+    source = (
+        "proc rhs() {\n"
+        "    emit \"rhs\"\n"
+        "    return true\n"
+        "}\n"
+        "if true or rhs() { emit \"ok\" } else { emit \"bad\" }\n"
+        "if true or (1 / 0) { emit \"ok\" } else { emit \"bad\" }\n"
+    )
+    ast = parse_source(source)
+    interpreter = Interpreter('<test>')
+    interpreter.execute(ast)
+    captured = capsys.readouterr().out.strip().splitlines()
+    assert captured == ['ok', 'ok']


### PR DESCRIPTION
## Summary
- add tokenizer, parser, and interpreter support for `or`
- document `or` precedence and short-circuit semantics
- test logical `or` parsing, precedence, and runtime behavior

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689168dd48808323b998b2285b6e6e98