### PR TITLE
feat: add first-class functions and closures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,16 @@
 ## 2025-08-05
 
 ### Added
+- Support for first-class functions and lexical closures
+- Example demonstrating higher-order function usage
+- Tests for assigning, passing, and returning functions
+
+### Changed
+- Parser and interpreter updated to treat procedures as values
+
+## 2025-08-05
+
+### Added
 - Initial `OMG_SPEC.md` defining core syntax, semantics, and runtime rules
 - `AGENTS.md` documenting expected behavior for intelligent assistants
 - `DEVELOPMENT.md` outlining development policy and roadmap

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -68,19 +68,21 @@ New features must:
 
 ---
 
+## Completed Features
+
+### First-Class Functions
+
+Functions are values: they can be assigned to variables, passed as arguments, and returned from other procedures.
+
+### Closures
+
+Inner procedures capture bindings from their enclosing scope, enabling lexical closures and higher-order patterns.
+
 ## Planned Features
 
 These features are under design and may be introduced incrementally:
 
-### ✅ First-Class Functions
-
-Functions will become values: assignable to variables, passable as arguments, and returnable from other functions.
-
-### ✅ Closures
-
-Inner functions will capture bindings from their enclosing scope, enabling lexical closures and higher-order patterns.
-
-### ✅ Import/Export System
+### Import/Export System
 
 Scripts will be able to import named procedures or constants from other `.omg` files, supporting modularization and reuse. Initially, this may be limited to top-level `proc` and `alloc` declarations.
 

--- a/OMG_SPEC.md
+++ b/OMG_SPEC.md
@@ -111,13 +111,40 @@ The following evaluate to false in a boolean context:
 
 ---
 
+## First-Class Functions and Closures
+
+Functions in OMG are values. Defining a function assigns it to a
+variable of the same name. Functions can be stored in variables, passed
+as arguments, and returned from other functions.
+
+```omg
+proc call_twice(f, x) { return f(f(x)) }
+proc inc(n) { return n + 1 }
+emit call_twice(inc, 3)   ; prints 5
+```
+
+Nested functions capture variables from the scope where they are
+defined, forming lexical closures. Captured values are preserved even if
+the inner function is returned or stored elsewhere.
+
+```omg
+proc make_adder(n) {
+    proc inner(x) { return x + n }
+    return inner
+}
+
+alloc add5 := make_adder(5)
+emit add5(10)   ; prints 15
+```
+
+---
+
 ## Interpreter Semantics
 
 ### Environments
 
 * `vars`: The current variable environment (scope)
 * `global_vars`: A preserved copy of global variables for function call isolation
-* `functions`: A map of function names to their (params, body) tuples
 
 ### Expression Evaluation
 

--- a/core/parser/expressions.py
+++ b/core/parser/expressions.py
@@ -76,7 +76,8 @@ def parse_factor(parser: 'Parser') -> tuple:
                     parser.eat('COMMA')
                     args.append(parser.expr())
             parser.eat('RPAREN')
-            return ('func_call', id_tok.value, args, id_tok.line)
+            func_expr = ('ident', id_tok.value, id_tok.line)
+            return ('func_call', func_expr, args, id_tok.line)
 
         if parser.curr_token.type == 'LBRACKET':
             parser.eat('LBRACKET')

--- a/examples/higher_order.omg
+++ b/examples/higher_order.omg
@@ -1,0 +1,21 @@
+;;;omg
+
+proc double(x) {
+    return x + x
+}
+
+proc apply_twice(f, x) {
+    return f(f(x))
+}
+
+emit apply_twice(double, 3)
+
+proc make_adder(n) {
+    proc inner(x) {
+        return x + n
+    }
+    return inner
+}
+
+alloc add5 := make_adder(5)
+emit add5(10)

--- a/tests/test_first_class_functions.py
+++ b/tests/test_first_class_functions.py
@@ -1,0 +1,34 @@
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from core.lexer import tokenize, Token
+from core.parser import Parser
+from core.interpreter import Interpreter
+
+
+def parse_source(source: str):
+    tokens, token_map = tokenize(source)
+    eof_line = tokens[-1].line if tokens else 1
+    tokens.append(Token('EOF', None, eof_line))
+    parser = Parser(tokens, token_map, '<test>')
+    return parser.parse()
+
+
+def test_first_class_functions_and_closures(capsys):
+    source = (
+        "proc inc(x) { return x + 1 }\n"
+        "proc call_twice(f, x) { return f(f(x)) }\n"
+        "proc make_adder(n) { proc inner(x) { return x + n } return inner }\n"
+        "alloc f := inc\n"
+        "emit f(2)\n"
+        "emit call_twice(f, 3)\n"
+        "alloc add5 := make_adder(5)\n"
+        "emit add5(10)\n"
+    )
+    ast = parse_source(source)
+    interpreter = Interpreter('<test>')
+    interpreter.execute(ast)
+    captured = capsys.readouterr().out.strip().splitlines()
+    assert captured == ['3', '5', '15']

--- a/tests/test_function_calls.py
+++ b/tests/test_function_calls.py
@@ -35,7 +35,9 @@ def test_call_ast_and_runtime(capsys):
     call2 = emit_stmt[1]
     assert call1[0] == 'func_call'
     assert call2[0] == 'func_call'
-    assert call1[:3] == call2[:3]
+    assert call1[1][0] == call2[1][0] == 'ident'
+    assert call1[1][1] == call2[1][1] == 'foo'
+    assert call1[2] == call2[2]
 
     interpreter = Interpreter('<test>')
     interpreter.execute(ast)


### PR DESCRIPTION
## Summary
- support functions as runtime values and implement lexical closures
- parse calls via expression-based callee to allow variable function invocation
- document and demonstrate higher-order functions with new example
- update development roadmap and changelog

## Testing
- `pytest`
- `python omg.py examples/higher_order.omg`


------
https://chatgpt.com/codex/tasks/task_e_68925e6e474883238f01909f635f701c