### PR TITLE
Fix module function scope for recursion and add tests

### DIFF
--- a/tests/test_modules.py
+++ b/tests/test_modules.py
@@ -79,3 +79,31 @@ def test_circular_import(tmp_path: Path):
     with pytest.raises(RuntimeError):
         run_file(main_file)
 
+
+def test_recursive_import_function(tmp_path: Path):
+    """Functions from imported modules should support recursion and be callable inside other functions."""
+    math_source = (
+        ";;;omg\n"
+        "proc factorial(n) {\n"
+        "    if n <= 1 {\n"
+        "        return 1\n"
+        "    } else {\n"
+        "        return n * factorial(n - 1)\n"
+        "    }\n"
+        "}\n"
+    )
+    math_file = tmp_path / "math.omg"
+    math_file.write_text(math_source)
+
+    main_source = (
+        ";;;omg\n"
+        f"import \"{math_file.name}\" as math\n"
+        "facts math.factorial(5) == 120\n"
+        "proc apply(n) { return math.factorial(n) }\n"
+        "facts apply(3) == 6\n"
+    )
+    main_file = tmp_path / "main.omg"
+    main_file.write_text(main_source)
+
+    run_file(main_file)
+


### PR DESCRIPTION
## Summary
- keep the defining module’s globals with each function value so recursion and cross-module calls resolve correctly
- update function invocation to restore both local and global scopes
- add regression test ensuring recursive imported functions work inside other functions

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68929b52c0948323b8aca49c1718f239