### PR TITLE
docs: describe module imports

### DIFF
--- a/spec/DEVELOPMENT.md
+++ b/spec/DEVELOPMENT.md
@@ -66,13 +66,11 @@ New features must:
 
 ---
 
-## Planned Features
+## Feature Status
 
-These features are under design and may be introduced incrementally:
+### Implemented
 
-### ✅ Import/Export System
-
-Scripts will be able to import named procedures or constants from other `.omg` files, supporting modularization and reuse. Initially, this may be limited to top-level `proc` and `alloc` declarations.
+* Import/Export System – Scripts can import named procedures or constants from other `.omg` files using `import "<file>" as <alias>`. Only top-level `proc` and `alloc` declarations are exported, and imported namespaces are read-only.
 
 ---
 

--- a/spec/OMG_LEXER.md
+++ b/spec/OMG_LEXER.md
@@ -69,6 +69,7 @@ Recognized with word boundaries (`\b`) to avoid false positives:
 
 * `if`, `elif`, `else`
 * `loop`, `break`
+* `import`, `as`
 * `alloc`, `emit`, `facts`, `proc`, `return`
 * `and`, `or`
 

--- a/spec/OMG_PARSER.md
+++ b/spec/OMG_PARSER.md
@@ -60,6 +60,8 @@ Statement parsing functions are defined in `statements.py`. The main dispatcher 
 
 * `emit x` → `('emit', expr_node, line)`
 
+* `import "utils.omg" as utils` → `('import', "utils.omg", "utils", line)`
+
 * `facts cond` → `('facts', expr_node, line)`
 
 * `loop cond { ... }` → `('loop', cond_node, block_node, line)`

--- a/spec/OMG_SPEC.md
+++ b/spec/OMG_SPEC.md
@@ -25,12 +25,24 @@ If this header is missing, the interpreter will raise an error and refuse to exe
 | `alloc`        | Declare and initialize variable    | `alloc x := 5`                    |
 | `:=`           | Reassign an existing variable      | `x := x + 1`                      |
 | `emit`         | Output value to console            | `emit "Hello"`                    |
+| `import`       | Load another script under an alias | `import "utils.omg" as utils`     |
 | `facts`        | Assert a condition (like `assert`) | `facts x > 0`                     |
 | `if/elif/else` | Conditional branches               | See below                         |
 | `loop`         | While-style loop                   | `loop x < 5 { ... }`              |
 | `break`        | Exit from current loop             | `break`                           |
 | `proc`         | Define function                    | `proc add(a, b) { return a + b }` |
 | `return`       | Return value from function         | `return result`                   |
+
+### Module Imports
+
+OMG scripts can import top-level procedures and constants from other files:
+
+```omg
+import "utils.omg" as utils
+emit utils.greet("World")
+```
+
+Only top-level `alloc` and `proc` declarations are exported. Imported namespaces are immutable, and recursive imports raise an error.
 
 ### Conditional Example
 

--- a/spec/feature/MODULE_SYSTEM.md
+++ b/spec/feature/MODULE_SYSTEM.md
@@ -1,6 +1,8 @@
-### **Task Introduction – Import/Export System for OMG**
+### **Module Import System**
 
-We are implementing a module import system for the OMG language. The goal is to allow OMG scripts to explicitly import functions and constants from other `.omg` files under a namespace. Only top-level `proc` and `alloc` declarations are exported; the rest of the file executes normally but cannot be accessed externally.
+Status: Implemented on 2025-08-06.
+
+The module system allows OMG scripts to explicitly import functions and constants from other `.omg` files under a namespace. Only top-level `proc` and `alloc` declarations are exported; the rest of the file executes normally but cannot be accessed externally.
 
 #### Goals and Design Constraints
 


### PR DESCRIPTION
## Summary
- document the new module import syntax and semantics
- note `import` and `as` tokens in the lexer spec
- mention import statements in parser docs and mark module system implemented

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6892a6f5ff70832396c2f512096d7bc6