### PR TITLE
feat: add OMG VS Code language server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 __pycache__
 build
 dist
+!ext/vscode-server/vscode-extension/dist/
+!ext/vscode-server/vscode-extension/dist/extension.js
 *.spec
 *.ps1
 scratchpad.omg
+node_modules

--- a/ext/vscode-server/README.md
+++ b/ext/vscode-server/README.md
@@ -1,0 +1,37 @@
+# OMG Language Server and VS Code Extension
+
+This directory contains a minimal Language Server Protocol (LSP) server for
+OMG and a matching VS Code extension.
+
+## Setup
+
+1. **Install Python dependencies**
+
+   ```bash
+   pip install pygls
+   ```
+
+2. **Build the VS Code extension**
+
+   ```bash
+   cd vscode-extension
+   npm install
+   npm run compile
+   ```
+
+3. **Link the extension in VS Code**
+
+   From the `vscode-extension` folder run:
+
+   ```bash
+   code --install-extension .
+   ```
+
+## Features
+
+- Go to definition for top-level `proc` and `alloc` declarations
+- Hover information with simple signatures
+- Document symbol outline
+
+Only files beginning with the required `;;;omg` header are processed by the
+language server.

--- a/ext/vscode-server/server/main.py
+++ b/ext/vscode-server/server/main.py
@@ -1,0 +1,227 @@
+"""OMG Language Server entry point.
+
+This server provides basic language features for OMG source files using
+`pygls`. It reuses the existing OMG lexer and parser to build a simple
+symbol index supporting definition lookup, hover information, and document
+symbols.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, List, Optional
+from urllib.parse import urlparse
+
+from pygls.server import LanguageServer
+from pygls.lsp.methods import (
+    TEXT_DOCUMENT_DEFINITION,
+    TEXT_DOCUMENT_HOVER,
+    TEXT_DOCUMENT_DOCUMENT_SYMBOL,
+    TEXT_DOCUMENT_DID_OPEN,
+    TEXT_DOCUMENT_DID_CHANGE,
+)
+from pygls.lsp.types import (
+    DefinitionParams,
+    DidOpenTextDocumentParams,
+    DidChangeTextDocumentParams,
+    DocumentSymbol,
+    DocumentSymbolParams,
+    Hover,
+    HoverParams,
+    Location,
+    MarkupContent,
+    MarkupKind,
+    Position,
+    Range,
+    SymbolKind,
+)
+
+from core.lexer import Token, tokenize
+from core.parser import Parser
+
+
+@dataclass
+class OMGSymbol:
+    """Represents a top-level symbol in an OMG file."""
+
+    name: str
+    kind: SymbolKind
+    uri: str
+    line: int
+    detail: str
+
+
+class OMGLanguageServer(LanguageServer):
+    """Language server for OMG source files."""
+
+    def __init__(self) -> None:
+        super().__init__("omg-ls", "v0.1")
+        self.symbols_by_uri: Dict[str, List[OMGSymbol]] = {}
+        self.global_symbols: Dict[str, List[OMGSymbol]] = {}
+        self.indexed_workspace = False
+
+    def _index_workspace(self) -> None:
+        """Parse all `.omg` files under the current workspace."""
+        root = self.workspace.root_path
+        if not root:
+            self.indexed_workspace = True
+            return
+        for path in Path(root).rglob("*.omg"):
+            uri = path.as_uri()
+            try:
+                text = path.read_text()
+            except OSError:
+                continue
+            self.update_index(uri, text)
+        self.indexed_workspace = True
+
+    def update_index(self, uri: str, text: str) -> None:
+        """Parse ``text`` and update symbol index for ``uri``.
+
+        Only files that begin with the required ``;;;omg`` header are
+        considered valid OMG files.
+        """
+        if not self._has_header(text):
+            return
+        symbols = self._parse_symbols(uri, text)
+        self.symbols_by_uri[uri] = symbols
+        self._rebuild_global_index()
+
+    def _rebuild_global_index(self) -> None:
+        self.global_symbols.clear()
+        for syms in self.symbols_by_uri.values():
+            for sym in syms:
+                self.global_symbols.setdefault(sym.name, []).append(sym)
+
+    @staticmethod
+    def _has_header(text: str) -> bool:
+        """Return ``True`` if the source begins with ``;;;omg``."""
+        for line in text.splitlines():
+            if line.strip() == "":
+                continue
+            return line.strip() == ";;;omg"
+        return False
+
+    def _parse_symbols(self, uri: str, text: str) -> List[OMGSymbol]:
+        """Parse ``text`` into AST and extract top-level symbols."""
+        tokens, token_map = tokenize(text)
+        eof_line = tokens[-1].line if tokens else 1
+        tokens.append(Token("EOF", None, eof_line))
+        parser = Parser(tokens, token_map, uri)
+        ast = parser.parse()
+        symbols: List[OMGSymbol] = []
+        for node in ast:
+            tag = node[0]
+            if tag == "func_def":
+                _, name, params, _, line = node
+                detail = f"proc {name}({', '.join(params)})"
+                symbols.append(
+                    OMGSymbol(name, SymbolKind.Function, uri, line - 1, detail)
+                )
+            elif tag == "decl":
+                _, name, _, line = node
+                detail = f"alloc {name}"
+                symbols.append(
+                    OMGSymbol(name, SymbolKind.Variable, uri, line - 1, detail)
+                )
+            elif tag == "import":
+                _, path, alias, _ = node
+                self._index_import(self._uri_to_path(uri), path, alias)
+        return symbols
+
+    def _index_import(self, base: Path, path: str, alias: str) -> None:
+        """Parse an imported file and record its symbols."""
+        import_path = (base.parent / path.strip("\"")).resolve()
+        if import_path.suffix != ".omg":
+            return
+        uri = import_path.as_uri()
+        if uri in self.symbols_by_uri:
+            return
+        try:
+            text = import_path.read_text()
+        except OSError:
+            return
+        self.update_index(uri, text)
+
+    @staticmethod
+    def _uri_to_path(uri: str) -> Path:
+        """Convert a file URI to a :class:`Path` instance."""
+        return Path(urlparse(uri).path)
+
+
+ls = OMGLanguageServer()
+
+
+@ls.feature(TEXT_DOCUMENT_DID_OPEN)
+def did_open(ls: OMGLanguageServer, params: DidOpenTextDocumentParams) -> None:
+    """Index a document when it is opened."""
+    ls.update_index(params.text_document.uri, params.text_document.text)
+
+
+@ls.feature(TEXT_DOCUMENT_DID_CHANGE)
+def did_change(ls: OMGLanguageServer, params: DidChangeTextDocumentParams) -> None:
+    """Re-index a document when it changes."""
+    if params.content_changes:
+        ls.update_index(params.text_document.uri, params.content_changes[0].text)
+
+
+@ls.feature(TEXT_DOCUMENT_DEFINITION)
+def definition(ls: OMGLanguageServer, params: DefinitionParams):
+    """Return the definition location for the symbol under the cursor."""
+    doc = ls.workspace.get_document(params.text_document.uri)
+    word = doc.word_at_position(params.position)
+    if not word:
+        return None
+    if not ls.indexed_workspace:
+        ls._index_workspace()
+    matches = ls.global_symbols.get(word)
+    if not matches:
+        return None
+    sym = matches[0]
+    rng = Range(Position(sym.line, 0), Position(sym.line, len(sym.name)))
+    return Location(uri=sym.uri, range=rng)
+
+
+@ls.feature(TEXT_DOCUMENT_HOVER)
+def hover(ls: OMGLanguageServer, params: HoverParams) -> Optional[Hover]:
+    """Return hover information for the symbol under the cursor."""
+    doc = ls.workspace.get_document(params.text_document.uri)
+    word = doc.word_at_position(params.position)
+    if not word:
+        return None
+    if not ls.indexed_workspace:
+        ls._index_workspace()
+    matches = ls.global_symbols.get(word)
+    if not matches:
+        return None
+    sym = matches[0]
+    contents = MarkupContent(kind=MarkupKind.PlainText, value=sym.detail)
+    return Hover(contents=contents)
+
+
+@ls.feature(TEXT_DOCUMENT_DOCUMENT_SYMBOL)
+def document_symbols(ls: OMGLanguageServer, params: DocumentSymbolParams):
+    """Return top-level symbols for the given document."""
+    symbols = ls.symbols_by_uri.get(params.text_document.uri, [])
+    result: List[DocumentSymbol] = []
+    for sym in symbols:
+        rng = Range(Position(sym.line, 0), Position(sym.line, len(sym.name)))
+        result.append(
+            DocumentSymbol(
+                name=sym.name,
+                kind=sym.kind,
+                range=rng,
+                selection_range=rng,
+                detail=sym.detail,
+            )
+        )
+    return result
+
+
+def main() -> None:
+    """Start the language server."""
+    ls.start_io()
+
+
+if __name__ == "__main__":
+    main()

--- a/ext/vscode-server/vscode-extension/dist/extension.js
+++ b/ext/vscode-server/vscode-extension/dist/extension.js
@@ -1,0 +1,59 @@
+"use strict";
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || (function () {
+    var ownKeys = function(o) {
+        ownKeys = Object.getOwnPropertyNames || function (o) {
+            var ar = [];
+            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
+            return ar;
+        };
+        return ownKeys(o);
+    };
+    return function (mod) {
+        if (mod && mod.__esModule) return mod;
+        var result = {};
+        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
+        __setModuleDefault(result, mod);
+        return result;
+    };
+})();
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.activate = activate;
+exports.deactivate = deactivate;
+const path = __importStar(require("path"));
+const node_1 = require("vscode-languageclient/node");
+let client;
+function activate(context) {
+    const serverModule = context.asAbsolutePath(path.join('..', 'server', 'main.py'));
+    const serverOptions = {
+        command: 'python',
+        args: [serverModule],
+    };
+    const clientOptions = {
+        documentSelector: [{ scheme: 'file', language: 'omg' }],
+    };
+    client = new node_1.LanguageClient('omg', 'OMG Language Server', serverOptions, clientOptions);
+    client.start();
+    context.subscriptions.push(client);
+}
+function deactivate() {
+    if (!client) {
+        return undefined;
+    }
+    return client.stop();
+}

--- a/ext/vscode-server/vscode-extension/extension.ts
+++ b/ext/vscode-server/vscode-extension/extension.ts
@@ -1,0 +1,28 @@
+import * as path from 'path';
+import * as vscode from 'vscode';
+import { LanguageClient, LanguageClientOptions, ServerOptions } from 'vscode-languageclient/node';
+
+let client: LanguageClient | undefined;
+
+export function activate(context: vscode.ExtensionContext) {
+    const serverModule = context.asAbsolutePath(path.join('..', 'server', 'main.py'));
+    const serverOptions: ServerOptions = {
+        command: 'python',
+        args: [serverModule],
+    };
+
+    const clientOptions: LanguageClientOptions = {
+        documentSelector: [{ scheme: 'file', language: 'omg' }],
+    };
+
+    client = new LanguageClient('omg', 'OMG Language Server', serverOptions, clientOptions);
+    client.start();
+    context.subscriptions.push(client);
+}
+
+export function deactivate(): Thenable<void> | undefined {
+    if (!client) {
+        return undefined;
+    }
+    return client.stop();
+}

--- a/ext/vscode-server/vscode-extension/package-lock.json
+++ b/ext/vscode-server/vscode-extension/package-lock.json
@@ -1,0 +1,139 @@
+{
+  "name": "omg-language-support",
+  "version": "0.0.1",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "omg-language-support",
+      "version": "0.0.1",
+      "dependencies": {
+        "vscode-languageclient": "^9.0.1"
+      },
+      "devDependencies": {
+        "@types/node": "^18.0.0",
+        "@types/vscode": "^1.82.0",
+        "typescript": "^5.0.0"
+      },
+      "engines": {
+        "vscode": "^1.82.0"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "18.19.121",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.121.tgz",
+      "integrity": "sha512-bHOrbyztmyYIi4f1R0s17QsPs1uyyYnGcXeZoGEd227oZjry0q6XQBQxd82X1I57zEfwO8h9Xo+Kl5gX1d9MwQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
+    "node_modules/@types/vscode": {
+      "version": "1.102.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.102.0.tgz",
+      "integrity": "sha512-V9sFXmcXz03FtYTSUsYsu5K0Q9wH9w9V25slddcxrh5JgORD14LpnOA7ov0L9ALi+6HrTjskLJ/tY5zeRF3TFA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "license": "MIT"
+    },
+    "node_modules/brace-expansion": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
+      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vscode-jsonrpc": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.2.0.tgz",
+      "integrity": "sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/vscode-languageclient": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-9.0.1.tgz",
+      "integrity": "sha512-JZiimVdvimEuHh5olxhxkht09m3JzUGwggb5eRUkzzJhZ2KjCN0nh55VfiED9oez9DyF8/fz1g1iBV3h+0Z2EA==",
+      "license": "MIT",
+      "dependencies": {
+        "minimatch": "^5.1.0",
+        "semver": "^7.3.7",
+        "vscode-languageserver-protocol": "3.17.5"
+      },
+      "engines": {
+        "vscode": "^1.82.0"
+      }
+    },
+    "node_modules/vscode-languageserver-protocol": {
+      "version": "3.17.5",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.5.tgz",
+      "integrity": "sha512-mb1bvRJN8SVznADSGWM9u/b07H7Ecg0I3OgXDuLdn307rl/J3A9YD6/eYOssqhecL27hK1IPZAsaqh00i/Jljg==",
+      "license": "MIT",
+      "dependencies": {
+        "vscode-jsonrpc": "8.2.0",
+        "vscode-languageserver-types": "3.17.5"
+      }
+    },
+    "node_modules/vscode-languageserver-types": {
+      "version": "3.17.5",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.5.tgz",
+      "integrity": "sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg==",
+      "license": "MIT"
+    }
+  }
+}

--- a/ext/vscode-server/vscode-extension/package.json
+++ b/ext/vscode-server/vscode-extension/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "omg-language-support",
+  "displayName": "OMG Language Support",
+  "version": "0.0.1",
+  "publisher": "omg",
+  "engines": {
+    "vscode": "^1.82.0"
+  },
+  "activationEvents": [
+    "onLanguage:omg"
+  ],
+  "main": "./dist/extension.js",
+  "contributes": {
+    "languages": [
+      {
+        "id": "omg",
+        "aliases": ["OMG", "omg"],
+        "extensions": [".omg"]
+      }
+    ]
+  },
+  "scripts": {
+    "compile": "tsc -p ./",
+    "watch": "tsc -watch -p ./"
+  },
+  "dependencies": {
+    "vscode-languageclient": "^9.0.1"
+  },
+  "devDependencies": {
+    "typescript": "^5.0.0",
+    "@types/node": "^18.0.0",
+    "@types/vscode": "^1.82.0"
+  }
+}

--- a/ext/vscode-server/vscode-extension/tsconfig.json
+++ b/ext/vscode-server/vscode-extension/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "target": "es2019",
+    "outDir": "./dist",
+    "rootDir": "./",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  },
+  "include": ["extension.ts"]
+}


### PR DESCRIPTION
## Summary
- add pygls-based OMG language server with definition, hover, and symbol features
- provide VS Code extension that launches the server for `.omg` files
- document setup steps for language server and extension

## Testing
- `python -m py_compile ext/vscode-server/server/main.py`
- `npm install`
- `npm run compile`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6892c21294288323b9a4e396ad2f556b