### PR TITLE
Add docblock comment support and highlighting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Ordered from most recent at the top to oldest at the bottom.
 ## [0.1.0] - 2025-08-06
 
 ### Added
+- Support for multiline `/** ... */` docblock comments in the lexer and VSCode syntax highlighting.
 - Introduced a full-featured VSCode extension for OMG:
   - Syntax highlighting via `omg.tmLanguage.json`
   - Language configuration (brackets, comments, etc.)

--- a/omglang/lexer.py
+++ b/omglang/lexer.py
@@ -5,9 +5,10 @@ regular expression of named groups. Each match yields a :class:`Token`
 containing its type, value and source line number.
 
 Tokens cover literals (numbers, strings, booleans), keywords (``if``, ``loop``,
-``emit`` …), operators and delimiters. Comment text beginning with ``#`` is
-skipped during tokenization so line numbers remain accurate. When present, the
-required ``;;;omg`` header is also stripped before lexing.
+``emit`` …), operators and delimiters. Comment text beginning with ``#`` or
+enclosed within ``/** … */`` docblocks is skipped during tokenization so line
+numbers remain accurate. When present, the required ``;;;omg`` header is also
+stripped before lexing.
 
 
 File: lexer.py
@@ -111,6 +112,9 @@ def tokenize(code) -> tuple[list[Token], dict[str, str]]:
         ('DOT',       r'\.'),
         ('COLON',     r':'),
 
+        # Comments
+        ('DOCBLOCK',  r'/\*\*(?:.|\n)*?\*/'),
+
         # Arithmetic operators
         ('PLUS',      r'\+'),
         ('MINUS',     r'-'),
@@ -168,6 +172,9 @@ def tokenize(code) -> tuple[list[Token], dict[str, str]]:
         if kind == 'SKIP':
             continue
         if kind == 'COMMENT':
+            continue
+        if kind == 'DOCBLOCK':
+            line_num += value.count('\n')
             continue
         if kind == 'MISMATCH':
             raise RuntimeError(f'Unexpected character {value} on line {line_num}')

--- a/omglang/tests/test_docblock_comments.py
+++ b/omglang/tests/test_docblock_comments.py
@@ -1,0 +1,21 @@
+"""Tests for docblock comments in OMG Language."""
+from omglang.interpreter import Interpreter
+from omglang.tests.utils import parse_source
+
+
+def test_docblock_comment_ignored(capsys):
+    """Ensure multiline docblock comments are skipped by the lexer."""
+    source = (
+        "/**\n"
+        " * Docblock comment\n"
+        " * spanning multiple lines\n"
+        " */\n"
+        "emit \"hi\"\n"
+    )
+    ast = parse_source(source)
+    assert len(ast) == 1
+    assert ast[0][0] == 'emit'
+
+    interpreter = Interpreter('<test>')
+    interpreter.execute(ast)
+    assert capsys.readouterr().out == "hi\n"

--- a/spec/OMG_LEXER.md
+++ b/spec/OMG_LEXER.md
@@ -107,7 +107,8 @@ Used for variable and function names. Keywords take precedence over identifiers 
 
 ## Special Tokens
 
-* `COMMENT`: `# ...` (skipped entirely)
+* `COMMENT`: `# ...` (single-line, skipped entirely)
+* `DOCBLOCK`: `/** ... */` (multiline docblock, skipped with line count preserved)
 * `SKIP`: spaces and tabs (ignored)
 * `NEWLINE`: triggers line number increment and emits a `NEWLINE` token
 * `MISMATCH`: catches unexpected characters and raises a `RuntimeError`

--- a/vscode/syntaxes/omg.tmLanguage.json
+++ b/vscode/syntaxes/omg.tmLanguage.json
@@ -24,6 +24,11 @@
         {
           "name": "comment.line.number-sign.omg",
           "match": "#.*$"
+        },
+        {
+          "name": "comment.block.documentation.omg",
+          "begin": "/\\*\\*",
+          "end": "\\*/"
         }
       ]
     },


### PR DESCRIPTION
## Summary
- support multiline `/** ... */` docblock comments in the lexer
- highlight docblock comments in VSCode grammar
- document and test new comment style

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6893eacf4eec83239bdbc7c80680b16c