### PR TITLE
Handle Windows-style module paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,10 @@ Ordered from most recent at the top to oldest at the bottom.
   compiled OMG programs.
 
 ### Fixed
+- Native VM resolves module paths with forward or backward slashes so
+  Windows-style imports load correctly.
+- Guarded native VM value formatting against cyclic structures to prevent
+  stack overflows when importing modules.
 - Reused temporary result variables in the self-hosted interpreter's
   `parse_factor` routine to avoid "Variable already declared" errors when
   running example scripts.


### PR DESCRIPTION
## Summary
- normalize slashes in `read_file` so Windows-style paths resolve correctly
- guard `Value::to_string` against cycles to avoid stack overflows when importing modules

## Testing
- `cargo run --manifest-path native/Cargo.toml -- ./bytecode/interpreter.bc -- ./examples/hello_world.omg`
- `cargo run --manifest-path native/Cargo.toml -- ./bytecode/interpreter.bc -- ./examples/import_modules.omg`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6894fc3bbdb083239a920002c3d0afca