### PR TITLE
feat: show usage for native VM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ Ordered from most recent at the top to oldest at the bottom.
 ## [Unreleased]
 
 ### Added
+- Native VM displays usage information when run without arguments or with
+  `-h`/`--help`.
 - Native VM now embeds the OMG interpreter bytecode and can execute `.omg`
   scripts directly; the bytecode is generated at build time via a Rust build
   script.


### PR DESCRIPTION
## Summary
- show detailed usage text when the native VM is run with no args or with -h/--help
- document the change in the changelog

## Testing
- `cargo test`
- `cargo run -- -h`


------
https://chatgpt.com/codex/tasks/task_e_689525cc77148323aa90a306a316b3f7