### PR TITLE
perf: optimize parser and compiler

### DIFF
--- a/bootstrap/compiler.omg
+++ b/bootstrap/compiler.omg
@@ -1,0 +1,520 @@
+;;;omg
+
+# OMG bytecode compiler implemented in OMG.
+# Usage: compiler <input.omg>
+#
+# Reuses tokenizer and parser from interpreter.omg to produce bytecode.
+
+import "./interpreter.omg" as omg
+
+# Utility helpers -------------------------------------------------
+
+proc contains(lst, item) {
+    alloc i := 0
+    alloc n := length(lst)
+    loop i < n {
+        if lst[i] == item {
+            return true
+        }
+        i := i + 1
+    }
+    return false
+}
+
+proc int_to_string(num) {
+    if num == 0 { return "0" }
+    alloc n := num
+    alloc neg := false
+    if n < 0 {
+        neg := true
+        n := 0 - n
+    }
+    alloc digits := ""
+    alloc d := 0
+    loop n > 0 {
+        d := n % 10
+        digits := chr(ascii("0") + d) + digits
+        n := n / 10
+    }
+    if neg { return "-" + digits }
+    return digits
+}
+
+proc escape_string(s) {
+    alloc res := ""
+    alloc i := 0
+    alloc n := length(s)
+    alloc c := ""
+    loop i < n {
+        c := s[i]
+        if c == "\\" {
+            res := res + "\\\\"
+        } elif c == "\"" {
+            res := res + "\\\""
+        } elif c == "\n" {
+            res := res + "\\n"
+        } elif c == "\r" {
+            res := res + "\\r"
+        } elif c == "\t" {
+            res := res + "\\t"
+        } else {
+            res := res + c
+        }
+        i := i + 1
+    }
+    return res
+}
+
+proc quote_string(s) {
+    return "\"" + escape_string(s) + "\""
+}
+
+# Compiler state --------------------------------------------------
+
+alloc code := []
+alloc pending_funcs := []
+alloc funcs := []
+alloc break_stack := []
+alloc builtins := ["chr", "ascii", "hex", "binary", "length", "read_file"]
+
+proc reset_state() {
+    code := []
+    pending_funcs := []
+    funcs := []
+    break_stack := []
+}
+
+proc emit_inst(op, arg) {
+    code[length(code)] := [op, arg]
+}
+
+proc emit_placeholder(op) {
+    alloc idx := length(code)
+    code[idx] := [op, 0]
+    return idx
+}
+
+proc patch(idx, target) { code[idx][1] := target }
+
+# Statement compilation ------------------------------------------
+
+proc compile_block(block) {
+    alloc i := 0
+    alloc n := length(block)
+    loop i < n {
+        compile_stmt(block[i])
+        i := i + 1
+    }
+}
+
+proc compile_stmt(stmt) {
+    alloc kind := stmt[0]
+    if kind == "emit" {
+        compile_expr(stmt[1])
+        emit_inst("EMIT", 0)
+    } elif kind == "decl" or kind == "assign" {
+        compile_expr(stmt[2])
+        emit_inst("STORE", stmt[1])
+    } elif kind == "attr_assign" {
+        compile_expr(stmt[1])
+        compile_expr(stmt[3])
+        emit_inst("STORE_ATTR", stmt[2])
+    } elif kind == "index_assign" {
+        compile_expr(stmt[1])
+        compile_expr(stmt[2])
+        compile_expr(stmt[3])
+        emit_inst("STORE_INDEX", 0)
+    } elif kind == "import" {
+        emit_inst("PUSH_STR", stmt[1])
+        emit_inst("IMPORT", 0)
+        emit_inst("STORE", stmt[2])
+    } elif kind == "facts" {
+        compile_expr(stmt[1])
+        emit_inst("ASSERT", 0)
+    } elif kind == "if" {
+        alloc cond_blocks := []
+        alloc else_block := []
+        alloc current := stmt
+        alloc cond := false
+        alloc block := []
+        alloc tail := false
+        loop true {
+            cond := current[1]
+            block := current[2]
+            cond_blocks[length(cond_blocks)] := [cond, block]
+            tail := current[3]
+            if length(tail) > 0 and tail[0] == "if" {
+                current := tail
+            } else {
+                if length(tail) > 0 { else_block := tail }
+                break
+            }
+        }
+        alloc end_jumps := []
+        alloc pair := false
+        alloc jf := 0
+        alloc i := 0
+        alloc n := length(cond_blocks)
+        loop i < n {
+            pair := cond_blocks[i]
+            compile_expr(pair[0])
+            jf := emit_placeholder("JUMP_IF_FALSE")
+            compile_block(pair[1])
+            end_jumps[length(end_jumps)] := emit_placeholder("JUMP")
+            patch(jf, length(code))
+            i := i + 1
+        }
+        if length(else_block) > 0 {
+            if else_block[0] == "if" {
+                compile_stmt(else_block)
+            } else {
+                compile_block(else_block)
+            }
+        }
+        i := 0
+        n := length(end_jumps)
+        loop i < n {
+            patch(end_jumps[i], length(code))
+            i := i + 1
+        }
+    } elif kind == "loop" {
+        alloc cond := stmt[1]
+        alloc body := stmt[2]
+        alloc start := length(code)
+        compile_expr(cond)
+        alloc jf := emit_placeholder("JUMP_IF_FALSE")
+        break_stack[length(break_stack)] := []
+        compile_block(body)
+        emit_inst("JUMP", start)
+        patch(jf, length(code))
+        alloc breaks := break_stack[length(break_stack) - 1]
+        alloc i := 0
+        alloc bn := length(breaks)
+        loop i < bn {
+            patch(breaks[i], length(code))
+            i := i + 1
+        }
+        break_stack := break_stack[0:length(break_stack) - 1]
+    } elif kind == "func_def" {
+        alloc name := stmt[1]
+        alloc params := stmt[2]
+        alloc body := stmt[3]
+        alloc body_code := compile_function_body(body)
+        pending_funcs[length(pending_funcs)] := [name, params, body_code]
+    } elif kind == "return" {
+        alloc expr := stmt[1]
+        if expr[0] == "func_call" and expr[1][0] == "ident" {
+            alloc func_name := expr[1][1]
+            alloc args := expr[2]
+            alloc j := 0
+            alloc m := length(args)
+            loop j < m {
+                compile_expr(args[j])
+                j := j + 1
+            }
+            if contains(builtins, func_name) {
+                emit_inst("BUILTIN", [func_name, m])
+                emit_inst("RET", 0)
+            } else {
+                emit_inst("TCALL", func_name)
+            }
+        } else {
+            compile_expr(expr)
+            emit_inst("RET", 0)
+        }
+    } elif kind == "break" {
+        alloc depth := length(break_stack)
+        if depth == 0 {
+            emit_inst("JUMP", length(code))
+        } else {
+            alloc idx := emit_placeholder("JUMP")
+            alloc top := break_stack[depth - 1]
+            top[length(top)] := idx
+            break_stack[depth - 1] := top
+        }
+    } else {
+        compile_expr(stmt)
+        emit_inst("POP", 0)
+    }
+}
+
+proc compile_function_body(body) {
+    alloc saved_code := code
+    alloc saved_break := break_stack
+    code := []
+    break_stack := []
+    compile_block(body)
+    emit_inst("RET", 0)
+    alloc body_code := code
+    code := saved_code
+    break_stack := saved_break
+    return body_code
+}
+
+
+# Expression compilation -----------------------------------------
+
+proc compile_expr(node) {
+    alloc op := node[0]
+    if op == "number" {
+        emit_inst("PUSH_INT", node[1])
+    } elif op == "string" {
+        emit_inst("PUSH_STR", node[1])
+    } elif op == "bool" {
+        if node[1] { emit_inst("PUSH_BOOL", 1) } else { emit_inst("PUSH_BOOL", 0) }
+    } elif op == "ident" {
+        emit_inst("LOAD", node[1])
+    } elif op == "list" {
+        alloc elems := node[1]
+        alloc i := 0
+        alloc n := length(elems)
+        loop i < n {
+            compile_expr(elems[i])
+            i := i + 1
+        }
+        emit_inst("BUILD_LIST", n)
+    } elif op == "dict" {
+        alloc pairs := node[1]
+        alloc i := 0
+        alloc n := length(pairs)
+        alloc pair := false
+        loop i < n {
+            pair := pairs[i]
+            emit_inst("PUSH_STR", pair[0][1])
+            compile_expr(pair[1])
+            i := i + 1
+        }
+        emit_inst("BUILD_DICT", n)
+    } elif op == "index" {
+        compile_expr(node[1])
+        compile_expr(node[2])
+        emit_inst("INDEX", 0)
+    } elif op == "slice" {
+        compile_expr(node[1])
+        compile_expr(node[2])
+        alloc end := node[3]
+        if end {
+            compile_expr(end)
+        } else {
+            emit_inst("PUSH_NONE", 0)
+        }
+        emit_inst("SLICE", 0)
+    } elif op == "dot" {
+        compile_expr(node[1])
+        emit_inst("ATTR", node[2])
+    } elif op == "func_call" {
+        alloc func_node := node[1]
+        alloc args := node[2]
+        alloc j := 0
+        alloc m := length(args)
+        if func_node[0] == "ident" {
+            alloc name := func_node[1]
+            loop j < m {
+                compile_expr(args[j])
+                j := j + 1
+            }
+            if contains(builtins, name) {
+                emit_inst("BUILTIN", [name, m])
+            } else {
+                emit_inst("CALL", name)
+            }
+        } else {
+            compile_expr(func_node)
+            loop j < m {
+                compile_expr(args[j])
+                j := j + 1
+            }
+            emit_inst("CALL_VALUE", m)
+        }
+    } elif op == "unary" {
+        alloc uop := node[1]
+        compile_expr(node[2])
+        if uop == "sub" { emit_inst("NEG", 0) }
+    } elif op == "bitnot" {
+        compile_expr(node[1])
+        emit_inst("NOT", 0)
+    } elif op == "add" {
+        compile_expr(node[1])
+        compile_expr(node[2])
+        emit_inst("ADD", 0)
+    } elif op == "sub" {
+        compile_expr(node[1])
+        compile_expr(node[2])
+        emit_inst("SUB", 0)
+    } elif op == "mul" {
+        compile_expr(node[1])
+        compile_expr(node[2])
+        emit_inst("MUL", 0)
+    } elif op == "div" {
+        compile_expr(node[1])
+        compile_expr(node[2])
+        emit_inst("DIV", 0)
+    } elif op == "mod" {
+        compile_expr(node[1])
+        compile_expr(node[2])
+        emit_inst("MOD", 0)
+    } elif op == "eq" {
+        compile_expr(node[1])
+        compile_expr(node[2])
+        emit_inst("EQ", 0)
+    } elif op == "ne" {
+        compile_expr(node[1])
+        compile_expr(node[2])
+        emit_inst("NE", 0)
+    } elif op == "lt" {
+        compile_expr(node[1])
+        compile_expr(node[2])
+        emit_inst("LT", 0)
+    } elif op == "gt" {
+        compile_expr(node[1])
+        compile_expr(node[2])
+        emit_inst("GT", 0)
+    } elif op == "le" {
+        compile_expr(node[1])
+        compile_expr(node[2])
+        emit_inst("LE", 0)
+    } elif op == "ge" {
+        compile_expr(node[1])
+        compile_expr(node[2])
+        emit_inst("GE", 0)
+    } elif op == "and" {
+        compile_expr(node[1])
+        compile_expr(node[2])
+        emit_inst("AND", 0)
+    } elif op == "or" {
+        compile_expr(node[1])
+        compile_expr(node[2])
+        emit_inst("OR", 0)
+    } elif op == "band" {
+        compile_expr(node[1])
+        compile_expr(node[2])
+        emit_inst("BAND", 0)
+    } elif op == "bor" {
+        compile_expr(node[1])
+        compile_expr(node[2])
+        emit_inst("BOR", 0)
+    } elif op == "bxor" {
+        compile_expr(node[1])
+        compile_expr(node[2])
+        emit_inst("BXOR", 0)
+    } elif op == "shl" {
+        compile_expr(node[1])
+        compile_expr(node[2])
+        emit_inst("SHL", 0)
+    } elif op == "shr" {
+        compile_expr(node[1])
+        compile_expr(node[2])
+        emit_inst("SHR", 0)
+    }
+}
+
+# Finalization ----------------------------------------------------
+
+proc finalize_code() {
+    alloc final_code := code
+    alloc i := 0
+    alloc n := length(pending_funcs)
+    alloc entry := false
+    alloc addr := 0
+    alloc body := []
+    loop i < n {
+        entry := pending_funcs[i]
+        addr := length(final_code)
+        funcs[length(funcs)] := [entry[0], entry[1], addr]
+        body := entry[2]
+        alloc j := 0
+        alloc m := length(body)
+        alloc instr := []
+        alloc op := ""
+        alloc arg := false
+        loop j < m {
+            instr := body[j]
+            op := instr[0]
+            arg := instr[1]
+            if (op == "JUMP" or op == "JUMP_IF_FALSE") and arg {
+                final_code[length(final_code)] := [op, arg + addr]
+            } else {
+                final_code[length(final_code)] := [op, arg]
+            }
+            j := j + 1
+        }
+        i := i + 1
+    }
+    return final_code
+}
+
+proc emit_code(final_code) {
+    alloc i := 0
+    alloc n := length(funcs)
+    alloc f := []
+    alloc line := ""
+    alloc params := []
+    alloc j := 0
+    alloc m := 0
+    loop i < n {
+        f := funcs[i]
+        line := "FUNC " + f[0] + " " + int_to_string(length(f[1]))
+        params := f[1]
+        j := 0
+        m := length(params)
+        loop j < m {
+            line := line + " " + params[j]
+            j := j + 1
+        }
+        line := line + " " + int_to_string(f[2])
+        emit line
+        i := i + 1
+    }
+    i := 0
+    n := length(final_code)
+    alloc instr := []
+    alloc op := ""
+    alloc arg := false
+    loop i < n {
+        instr := final_code[i]
+        op := instr[0]
+        arg := instr[1]
+        if op == "BUILTIN" {
+            line := "BUILTIN " + arg[0] + " " + int_to_string(arg[1])
+        } elif op == "PUSH_STR" {
+            line := "PUSH_STR " + quote_string(arg)
+        } elif op == "STORE" or op == "LOAD" or op == "CALL" or op == "TCALL" or op == "ATTR" or op == "STORE_ATTR" {
+            line := op + " " + arg
+        } elif arg == 0 {
+            line := op
+        } else {
+            line := op + " " + int_to_string(arg)
+        }
+        emit line
+        i := i + 1
+    }
+}
+
+proc compile(ast) {
+    alloc i := 0
+    alloc n := length(ast)
+    loop i < n {
+        compile_stmt(ast[i])
+        i := i + 1
+    }
+    emit_inst("HALT", 0)
+    alloc final_code := finalize_code()
+    emit_code(final_code)
+}
+
+proc compile_source(source) {
+    reset_state()
+    alloc ast := omg.parse(source)
+    compile(ast)
+}
+
+# CLI ------------------------------------------------------------
+
+if length(args) > 0 {
+    alloc path := args[0]
+    alloc src := read_file(path)
+    compile_source(src)
+} else {
+    emit "Usage: compiler <input.omg>"
+}
+

--- a/bootstrap/interpreter.omg
+++ b/bootstrap/interpreter.omg
@@ -167,7 +167,7 @@ proc parse_program(tokens, i) {
     alloc res := [false, i]
     loop res[1] < tok_len {
         res := parse_statement(tokens, res[1])
-        stmts := stmts + [res[0]]
+        stmts[length(stmts)] := res[0]
     }
     return [stmts, res[1]]
 }
@@ -202,7 +202,7 @@ proc parse_statement(tokens, i) {
         loop j < tok_len and tokens[j][0] == "kw" and tokens[j][1] == "elif" {
             res_elif := parse_expression(tokens, j + 1)
             res_block := parse_block(tokens, res_elif[1])
-            elifs := elifs + [[res_elif[0], res_block[0]]]
+            elifs[length(elifs)] := [res_elif[0], res_block[0]]
             j := res_block[1]
         }
         if j < tok_len and tokens[j][0] == "kw" and tokens[j][1] == "else" {
@@ -223,7 +223,7 @@ proc parse_statement(tokens, i) {
         alloc params := []
         if tokens[j][0] != "symbol" or tokens[j][1] != ")" {
             loop true {
-                params := params + [tokens[j][1]]
+                params[length(params)] := tokens[j][1]
                 j := j + 1
                 if tokens[j][0] == "symbol" and tokens[j][1] == "," {
                     j := j + 1
@@ -266,7 +266,7 @@ proc parse_block(tokens, i) {
     j := j + 1
     loop tokens[j][0] != "symbol" or tokens[j][1] != "}" {
         res := parse_statement(tokens, j)
-        stmts := stmts + [res[0]]
+        stmts[length(stmts)] := res[0]
         j := res[1]
     }
     return [stmts, j + 1]
@@ -451,7 +451,7 @@ proc parse_factor(tokens, i) {
         if tokens[k][0] != "symbol" or tokens[k][1] != "]" {
             loop true {
                 res := parse_expression(tokens, k)
-                elems := elems + [res[0]]
+                elems[length(elems)] := res[0]
                 k := res[1]
                 if tokens[k][0] == "symbol" and tokens[k][1] == "," {
                     k := k + 1
@@ -482,7 +482,7 @@ proc parse_factor(tokens, i) {
                 }
                 k := k + 1
                 val_res := parse_expression(tokens, k)
-                pairs := pairs + [[key_node, val_res[0]]]
+                pairs[length(pairs)] := [key_node, val_res[0]]
                 k := val_res[1]
                 if tokens[k][0] == "symbol" and tokens[k][1] == "," {
                     k := k + 1
@@ -503,7 +503,7 @@ proc parse_factor(tokens, i) {
     }
     alloc inner := [false, 0]
     alloc end_res := [false, 0]
-    alloc call_args := []
+        alloc call_args := []
     res := [false, 0]
     alloc attr := [false, false]
     loop j < tok_len and tokens[j][0] == "symbol" {
@@ -513,7 +513,7 @@ proc parse_factor(tokens, i) {
             if tokens[k][0] != "symbol" or tokens[k][1] != ")" {
                 loop true {
                     res := parse_expression(tokens, k)
-                    call_args := call_args + [res[0]]
+                    call_args[length(call_args)] := res[0]
                     k := res[1]
                     if tokens[k][0] == "symbol" and tokens[k][1] == "," {
                         k := k + 1
@@ -588,7 +588,7 @@ proc env_set(env, name, value) {
         }
         i := i + 1
     }
-    env := env + [[name, value]]
+    env[length(env)] := [name, value]
     return env
 }
 proc copy_env(env) {
@@ -598,7 +598,7 @@ proc copy_env(env) {
     alloc env_len := length(env)
     loop i < env_len {
         entry := env[i]
-        result := result + [entry]
+        result[length(result)] := entry
         i := i + 1
     }
     return result
@@ -673,7 +673,7 @@ proc import_module(path) {
         }
         k := k + 1
     }
-    loaded_modules := loaded_modules + [full]
+    loaded_modules[length(loaded_modules)] := full
     alloc source := read_file(full)
     alloc src_len := length(source)
     if src_len >= 6 and source[0] == ";" and source[1] == ";" and source[2] == ";" and source[3] == "o" and source[4] == "m" and source[5] == "g" {
@@ -697,7 +697,7 @@ proc import_module(path) {
     loop i < ast_len {
         stmt := ast[i]
         if stmt[0] == "decl" or stmt[0] == "func_def" {
-            exports := exports + [stmt[1]]
+            exports[length(exports)] := stmt[1]
         }
         i := i + 1
     }
@@ -799,7 +799,7 @@ proc eval_expr(expr, env) {
         alloc i := 0
         alloc nodes_len := length(nodes)
         loop i < nodes_len {
-            result := result + [eval_expr(nodes[i], env)]
+            result[length(result)] := eval_expr(nodes[i], env)
             i := i + 1
         }
         return result
@@ -843,7 +843,7 @@ proc eval_expr(expr, env) {
         alloc i := 0
         alloc arg_len := length(arg_nodes)
         loop i < arg_len {
-            arg_values := arg_values + [eval_expr(arg_nodes[i], env)]
+            arg_values[length(arg_values)] := eval_expr(arg_nodes[i], env)
             i := i + 1
         }
         return call_function(func_val, arg_values, env)
@@ -947,7 +947,7 @@ proc execute(stmts, env, is_global) {
             j := 0
             arg_len := length(arg_nodes)
             loop j < arg_len {
-                call_args := call_args + [eval_expr(arg_nodes[j], env)]
+                call_args[length(call_args)] := eval_expr(arg_nodes[j], env)
                 j := j + 1
             }
             _ := call_function(func_val, call_args, env)

--- a/omglang/interpreter.py
+++ b/omglang/interpreter.py
@@ -612,11 +612,14 @@ class Interpreter:
                         raise TypeError(
                             f"List index must be int on line {line} in {self.file}"
                         )
-                    if not 0 <= key < len(target):
+                    if key == len(target):
+                        target.append(value)
+                    elif 0 <= key < len(target):
+                        target[key] = value
+                    else:
                         raise RuntimeError(
                             f"List index out of bounds on line {line} in {self.file}"
                         )
-                    target[key] = value
                 else:
                     raise TypeError(
                         f"{self._format_expr(obj_expr)} is not indexable on line {line} in {self.file}"


### PR DESCRIPTION
## Summary
- allow appending to lists by assigning at index equal to list length
- refactor OMG parser and runtime to use index-based appends for faster AST and environment building
- emit bytecode lines directly from compiler to avoid expensive string joins

## Testing
- `python omg.py bootstrap/compiler.omg /tmp/simple.omg`
- `python omg.py bootstrap/compiler.omg bootstrap/test_interpret.omg >/tmp/compiler.log && tail -n 20 /tmp/compiler.log`
- `timeout 180 python omg.py bootstrap/compiler.omg bootstrap/interpreter.omg >/tmp/interpreter.bc` *(did not finish within timeout)*

------
https://chatgpt.com/codex/tasks/task_e_68953aa4306c83239b256daa210c6859