### PR TITLE
Allow variable redeclaration inside loops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ Ordered from most recent at the top to oldest at the bottom.
 - Native VM understands additional bytecode operations like attribute access,
   assertions, imports, and indirect function calls, paving the way for fully
   compiled OMG programs.
+- Loop bodies now create a fresh scope each iteration, allowing variables
+  declared with `alloc` to be redeclared inside loops.
 
 ### Fixed
 - Native VM resolves module paths with forward or backward slashes so

--- a/bootstrap/interpreter.omg
+++ b/bootstrap/interpreter.omg
@@ -854,28 +854,10 @@ proc eval_expr(expr, env) {
 }
 proc execute(stmts, env, is_global) {
     alloc i := 0
-    alloc stmt := false
-    alloc kind := false
-    alloc res := ["normal", false]
     alloc stmts_len := length(stmts)
-    alloc cond := false
-    alloc loop_res := ["normal", false]
-    alloc val := false
-    alloc name := ""
-    alloc params := []
-    alloc body := []
-    alloc func_val := false
-    alloc arg_nodes := []
-    alloc call_args := []
-    alloc j := 0
-    alloc arg_len := 0
-    alloc obj := false
-    alloc attr := ""
-    alloc idx := false
-    alloc _ := false
     loop i < stmts_len {
-        stmt := stmts[i]
-        kind := stmt[0]
+        alloc stmt := stmts[i]
+        alloc kind := stmt[0]
         if kind == "decl" {
             env := env_set(env, stmt[1], eval_expr(stmt[2], env))
             if is_global { global_env := env }
@@ -883,25 +865,25 @@ proc execute(stmts, env, is_global) {
             env := env_set(env, stmt[1], eval_expr(stmt[2], env))
             if is_global { global_env := env }
         } elif kind == "attr_assign" {
-            obj := eval_expr(stmt[1], env)
-            attr := stmt[2]
+            alloc obj := eval_expr(stmt[1], env)
+            alloc attr := stmt[2]
             obj[attr] := eval_expr(stmt[3], env)
         } elif kind == "index_assign" {
-            obj := eval_expr(stmt[1], env)
-            idx := eval_expr(stmt[2], env)
+            alloc obj := eval_expr(stmt[1], env)
+            alloc idx := eval_expr(stmt[2], env)
             obj[idx] := eval_expr(stmt[3], env)
         } elif kind == "emit" {
             emit eval_expr(stmt[1], env)
         } elif kind == "facts" {
-            cond := eval_expr(stmt[1], env)
+            alloc cond := eval_expr(stmt[1], env)
             if cond {
-                _ := false
+                alloc _ := false
             } else {
                 emit "Assertion failed"
             }
         } elif kind == "if" {
-            cond := eval_expr(stmt[1], env)
-            res := ["normal", false]
+            alloc cond := eval_expr(stmt[1], env)
+            alloc res := ["normal", false]
             if cond {
                 res := execute(stmt[2], env, is_global)
             } elif length(stmt) > 3 {
@@ -911,9 +893,11 @@ proc execute(stmts, env, is_global) {
                 return res
             }
         } elif kind == "loop" {
-            loop_res := ["normal", false]
             loop eval_expr(stmt[1], env) {
-                loop_res := execute(stmt[2], env, is_global)
+                alloc pre_len := length(env)
+                alloc loop_res := execute(stmt[2], env, is_global)
+                env := env[0:pre_len]
+                if is_global { global_env := env }
                 if loop_res[0] == "break" {
                     break
                 } elif loop_res[0] == "return" {
@@ -923,12 +907,13 @@ proc execute(stmts, env, is_global) {
         } elif kind == "break" {
             return ["break", false]
         } elif kind == "return" {
-            val := eval_expr(stmt[1], env)
+            alloc val := eval_expr(stmt[1], env)
             return ["return", val]
         } elif kind == "func_def" {
-            name := stmt[1]
-            params := stmt[2]
-            body := stmt[3]
+            alloc name := stmt[1]
+            alloc params := stmt[2]
+            alloc body := stmt[3]
+            alloc func_val := false
             if is_global {
                 func_val := ["function", params, body, "global"]
             } else {
@@ -937,20 +922,20 @@ proc execute(stmts, env, is_global) {
             env := env_set(env, name, func_val)
             if is_global { global_env := env }
         } elif kind == "import" {
-            obj := import_module(stmt[1])
+            alloc obj := import_module(stmt[1])
             env := env_set(env, stmt[2], obj)
             if is_global { global_env := env }
         } elif kind == "func_call" {
-            func_val := eval_expr(stmt[1], env)
-            arg_nodes := stmt[2]
-            call_args := []
-            j := 0
-            arg_len := length(arg_nodes)
+            alloc func_val := eval_expr(stmt[1], env)
+            alloc arg_nodes := stmt[2]
+            alloc call_args := []
+            alloc j := 0
+            alloc arg_len := length(arg_nodes)
             loop j < arg_len {
                 call_args := call_args + [eval_expr(arg_nodes[j], env)]
                 j := j + 1
             }
-            _ := call_function(func_val, call_args, env)
+            alloc _ := call_function(func_val, call_args, env)
         } else {
             emit "Unknown statement: " + kind
         }

--- a/bootstrap/test_interpret.omg
+++ b/bootstrap/test_interpret.omg
@@ -12,6 +12,13 @@ alloc lines := [
     "}",
     "alloc result := fact(5)",
     "emit result",
+    "",
+    "alloc i := 0",
+    "loop i < 3 {",
+    "    alloc x := i",
+    "    emit x",
+    "    i := i + 1",
+    "}",
 ]
 
 alloc i := 0

--- a/omglang/interpreter.py
+++ b/omglang/interpreter.py
@@ -655,10 +655,20 @@ class Interpreter:
                 _, cond_node, block_node, _ = stmt
                 try:
                     while self.eval_expr(cond_node):
+                        pre_loop_vars = set(self.vars.keys())
                         try:
                             self.execute([block_node])
                         except BreakLoop:
+                            # Clean up iteration-scoped variables before exiting the loop
+                            for name in list(self.vars.keys()):
+                                if name not in pre_loop_vars:
+                                    del self.vars[name]
                             break
+                        # Remove variables declared during this iteration so the next
+                        # iteration sees a fresh environment for loop-local variables.
+                        for name in list(self.vars.keys()):
+                            if name not in pre_loop_vars:
+                                del self.vars[name]
                 except BreakLoop:
                     pass
 

--- a/omglang/tests/test_loops_and_facts.py
+++ b/omglang/tests/test_loops_and_facts.py
@@ -61,3 +61,20 @@ def test_facts_failure():
     interpreter = Interpreter('<test>')
     with pytest.raises(AssertionError):
         interpreter.execute(ast)
+
+
+def test_loop_allows_redeclaration(capsys):
+    """Variables declared with ``alloc`` inside loops can be redeclared each iteration."""
+    source = (
+        "alloc i := 0\n"
+        "loop i < 3 {\n"
+        "    alloc x := i\n"
+        "    emit x\n"
+        "    i := i + 1\n"
+        "}\n"
+    )
+    ast = parse_source(source)
+    interpreter = Interpreter('<test>')
+    interpreter.execute(ast)
+    captured = capsys.readouterr().out.strip().splitlines()
+    assert captured == ['0', '1', '2']

--- a/spec/OMG_SPEC.md
+++ b/spec/OMG_SPEC.md
@@ -65,6 +65,10 @@ loop x > 0 {
 }
 ```
 
+Variables declared with `alloc` inside a loop are scoped to each iteration.
+They can be redeclared on subsequent iterations and are not visible after the
+loop completes.
+
 ---
 
 ## Expressions


### PR DESCRIPTION
## Summary
- Reset loop-local variables each iteration to permit `alloc` redeclaration
- Document per-iteration scope for loop `alloc` declarations
- Test redeclaration of `alloc` variables inside loops
- Scope loop variables per iteration in self-hosted interpreter and add test case exercising redeclaration

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689553a5b92083239a3caeba7ae04410