### PR TITLE
Raise FrozenWriteError when modifying frozen dicts

### DIFF
--- a/runtime/src/main.rs
+++ b/runtime/src/main.rs
@@ -16,7 +16,8 @@ const INTERPRETER_BC: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/interpre
 const VERSION: &str = "0.1.1";
 
 fn usage() -> String {
-    format!(r#"OMG Language Runtime v{0}
+    format!(
+        r#"OMG Language Runtime v{0}
 
 Usage:
     omg <script.omg>
@@ -33,7 +34,9 @@ Options:
     -h, --help
         Show this help message and exit.
     --version
-        Show runtime version."#, VERSION)
+        Show runtime version."#,
+        VERSION
+    )
 }
 
 fn main() {
@@ -68,7 +71,10 @@ fn main() {
         };
         let src = fs::read(bc_path).expect("failed to read bytecode file");
         let (code, funcs) = parse_bytecode(&src);
-        run(&code, &funcs, program_args);
+        if let Err(e) = run(&code, &funcs, program_args) {
+            eprintln!("{}", e);
+            std::process::exit(1);
+        }
     } else {
         let prog_path = &args[1];
         let program_args_slice: &[String] = if args.len() > 2 {
@@ -84,6 +90,9 @@ fn main() {
         full_args.push(prog_path.clone());
         full_args.extend_from_slice(program_args_slice);
         let (code, funcs) = parse_bytecode(INTERPRETER_BC);
-        run(&code, &funcs, &full_args);
+        if let Err(e) = run(&code, &funcs, &full_args) {
+            eprintln!("{}", e);
+            std::process::exit(1);
+        }
     }
 }


### PR DESCRIPTION
## Summary
- add `VmError::FrozenWriteError` to signal attempts to modify frozen dicts
- surface `FrozenWriteError: Imported modules are read-only` instead of panicking
- update runtime CLI to print errors and add unit test

## Testing
- `cargo test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6896bba9fc608323b128bae12d68b4a7