### PR TITLE
Handle assertion failures as RuntimeError

### DIFF
--- a/runtime/src/error.rs
+++ b/runtime/src/error.rs
@@ -15,6 +15,8 @@ pub enum RuntimeError {
     IndexError(String),
     /// User-raised runtime error.
     Raised(String),
+    /// An assertion failed.
+    AssertionError,
 }
 
 impl fmt::Display for RuntimeError {
@@ -37,6 +39,9 @@ impl fmt::Display for RuntimeError {
             }
             RuntimeError::Raised(msg) => {
                 write!(f, "RuntimeError: {}", msg)
+            }
+            RuntimeError::AssertionError => {
+                write!(f, "AssertionError: assertion failed")
             }
         }
     }

--- a/runtime/src/vm.rs
+++ b/runtime/src/vm.rs
@@ -57,7 +57,7 @@ pub fn run(
     while pc < code.len() {
         let mut advance_pc = true;
         let instr_res: Result<(), RuntimeError> = loop {
-        match &code[pc] {
+            match &code[pc] {
                 Instr::PushInt(v) => stack.push(Value::Int(*v)),
                 Instr::PushStr(s) => stack.push(Value::Str(s.clone())),
                 Instr::PushBool(b) => stack.push(Value::Bool(*b)),
@@ -138,7 +138,7 @@ pub fn run(
                 Instr::Mod => {
                     let b = stack.pop().unwrap().as_int();
                     if b == 0 {
-                    break Err(RuntimeError::ZeroDivisionError);
+                        break Err(RuntimeError::ZeroDivisionError);
                     }
                     let a = stack.pop().unwrap().as_int();
                     stack.push(Value::Int(a % b));
@@ -238,7 +238,7 @@ pub fn run(
                     match (base, idx) {
                         (Value::List(list), Value::Int(i)) => {
                             if i < 0 {
-                            break Err(RuntimeError::IndexError(
+                                break Err(RuntimeError::IndexError(
                                     "List index out of bounds!".to_string(),
                                 ));
                             }
@@ -247,7 +247,7 @@ pub fn run(
                             if idx_usize < l.len() {
                                 stack.push(l[idx_usize].clone());
                             } else {
-                            break Err(RuntimeError::IndexError(
+                                break Err(RuntimeError::IndexError(
                                     "List index out of bounds!".to_string(),
                                 ));
                             }
@@ -256,7 +256,7 @@ pub fn run(
                             if let Some(v) = map.borrow().get(&k).cloned() {
                                 stack.push(v);
                             } else {
-                            break Err(RuntimeError::KeyError(k));
+                                break Err(RuntimeError::KeyError(k));
                             }
                         }
                         (Value::Dict(map), Value::Int(i)) => {
@@ -264,14 +264,14 @@ pub fn run(
                             if let Some(v) = map.borrow().get(&key).cloned() {
                                 stack.push(v);
                             } else {
-                            break Err(RuntimeError::KeyError(key));
+                                break Err(RuntimeError::KeyError(key));
                             }
                         }
                         (Value::FrozenDict(map), Value::Str(k)) => {
                             if let Some(v) = map.get(&k).cloned() {
                                 stack.push(v);
                             } else {
-                            break Err(RuntimeError::KeyError(k));
+                                break Err(RuntimeError::KeyError(k));
                             }
                         }
                         (Value::FrozenDict(map), Value::Int(i)) => {
@@ -279,12 +279,12 @@ pub fn run(
                             if let Some(v) = map.get(&key).cloned() {
                                 stack.push(v);
                             } else {
-                            break Err(RuntimeError::KeyError(key));
+                                break Err(RuntimeError::KeyError(key));
                             }
                         }
                         (Value::Str(s), Value::Int(i)) => {
                             if i < 0 {
-                            break Err(RuntimeError::IndexError(
+                                break Err(RuntimeError::IndexError(
                                     "String index out of bounds!".to_string(),
                                 ));
                             }
@@ -293,13 +293,13 @@ pub fn run(
                             if idx_usize < chars.len() {
                                 stack.push(Value::Str(chars[idx_usize].to_string()));
                             } else {
-                            break Err(RuntimeError::IndexError(
+                                break Err(RuntimeError::IndexError(
                                     "String index out of bounds!".to_string(),
                                 ));
                             }
                         }
                         (other, _) => {
-                        break Err(RuntimeError::TypeError(format!(
+                            break Err(RuntimeError::TypeError(format!(
                                 "{} is not indexable",
                                 other.to_string()
                             )));
@@ -352,7 +352,7 @@ pub fn run(
                             map.borrow_mut().insert(i.to_string(), val);
                         }
                         (Value::FrozenDict(_), _) => {
-                        break Err(RuntimeError::FrozenWriteError);
+                            break Err(RuntimeError::FrozenWriteError);
                         }
                         _ => {}
                     }
@@ -364,18 +364,18 @@ pub fn run(
                             if let Some(v) = map.borrow().get(attr).cloned() {
                                 stack.push(v);
                             } else {
-                            break Err(RuntimeError::KeyError(attr.clone()));
+                                break Err(RuntimeError::KeyError(attr.clone()));
                             }
                         }
                         Value::FrozenDict(map) => {
                             if let Some(v) = map.get(attr).cloned() {
                                 stack.push(v);
                             } else {
-                            break Err(RuntimeError::KeyError(attr.clone()));
+                                break Err(RuntimeError::KeyError(attr.clone()));
                             }
                         }
                         other => {
-                        break Err(RuntimeError::TypeError(format!(
+                            break Err(RuntimeError::TypeError(format!(
                                 "{} has no attribute '{}'",
                                 other.to_string(),
                                 attr
@@ -391,7 +391,7 @@ pub fn run(
                             map.borrow_mut().insert(attr.clone(), val);
                         }
                         Value::FrozenDict(_) => {
-                        break Err(RuntimeError::FrozenWriteError);
+                            break Err(RuntimeError::FrozenWriteError);
                         }
                         _ => {}
                     }
@@ -399,7 +399,7 @@ pub fn run(
                 Instr::Assert => {
                     let cond = stack.pop().unwrap().as_bool();
                     if !cond {
-                        panic!("Assertion failed");
+                        break Err(RuntimeError::AssertionError);
                     }
                 }
                 Instr::CallValue(argc) => {
@@ -586,12 +586,12 @@ pub fn run(
                 Instr::PopBlock => {
                     block_stack.pop();
                 }
-            Instr::Raise => {
-                let msg = stack.pop().unwrap().to_string();
-                break Err(RuntimeError::Raised(msg));
+                Instr::Raise => {
+                    let msg = stack.pop().unwrap().to_string();
+                    break Err(RuntimeError::Raised(msg));
+                }
             }
-        }
-        break Ok(());
+            break Ok(());
         };
 
         if let Err(e) = instr_res {

--- a/runtime/src/vm/tests.rs
+++ b/runtime/src/vm/tests.rs
@@ -70,3 +70,28 @@ fn uncaught_raise_surfaces() {
     let result = run(&code, &funcs, &[]);
     assert_eq!(result, Err(RuntimeError::Raised("boom".to_string())));
 }
+
+#[test]
+fn uncaught_assert_surfaces() {
+    let code = vec![Instr::PushBool(false), Instr::Assert, Instr::Halt];
+    let funcs = HashMap::new();
+    let result = run(&code, &funcs, &[]);
+    assert_eq!(result, Err(RuntimeError::AssertionError));
+}
+
+#[test]
+fn assert_caught_in_block() {
+    let code = vec![
+        Instr::SetupExcept(5),
+        Instr::PushBool(false),
+        Instr::Assert,
+        Instr::PopBlock,
+        Instr::Jump(7),
+        Instr::Pop,
+        Instr::Halt,
+        Instr::Halt,
+    ];
+    let funcs = HashMap::new();
+    let result = run(&code, &funcs, &[]);
+    assert!(result.is_ok());
+}


### PR DESCRIPTION
## Summary
- add `AssertionError` to runtime error enum
- return `AssertionError` instead of panicking for failed `ASSERT`
- test assertion propagation and catching with `SETUP_EXCEPT`

## Testing
- `cd runtime && cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6898b44fc74c8323889f8ddeaf0cadcb