### PR TITLE
Handle VM builtin type errors gracefully

### DIFF
--- a/runtime/src/vm.rs
+++ b/runtime/src/vm.rs
@@ -478,60 +478,84 @@ pub fn run(
                         args.push(stack.pop().unwrap());
                     }
                     args.reverse();
-                    let result = match name.as_str() {
+                    let result: Result<Value, RuntimeError> = match name.as_str() {
                         "chr" => match args.as_slice() {
-                            [Value::Int(i)] => Value::Str((*i as u8 as char).to_string()),
-                            _ => panic!("chr() expects one integer"),
+                            [Value::Int(i)] => Ok(Value::Str((*i as u8 as char).to_string())),
+                            _ => Err(RuntimeError::TypeError(
+                                "chr() expects one integer".to_string(),
+                            )),
                         },
                         "ascii" => match args.as_slice() {
                             [Value::Str(s)] if s.chars().count() == 1 => {
-                                Value::Int(s.chars().next().unwrap() as i64)
+                                Ok(Value::Int(s.chars().next().unwrap() as i64))
                             }
-                            _ => panic!("ascii() expects a single character"),
+                            _ => Err(RuntimeError::TypeError(
+                                "ascii() expects a single character".to_string(),
+                            )),
                         },
                         "hex" => match args.as_slice() {
-                            [Value::Int(i)] => Value::Str(format!("{:x}", i)),
-                            _ => panic!("hex() expects one integer"),
+                            [Value::Int(i)] => Ok(Value::Str(format!("{:x}", i))),
+                            _ => Err(RuntimeError::TypeError(
+                                "hex() expects one integer".to_string(),
+                            )),
                         },
                         "binary" => match args.as_slice() {
-                            [Value::Int(n)] => Value::Str(format!("{:b}", n)),
+                            [Value::Int(n)] => Ok(Value::Str(format!("{:b}", n))),
                             [Value::Int(n), Value::Int(width)] => {
                                 if *width <= 0 {
-                                    panic!("binary() width must be positive");
+                                    Err(RuntimeError::TypeError(
+                                        "binary() width must be positive".to_string(),
+                                    ))
+                                } else {
+                                    let mask = (1_i64 << width) - 1;
+                                    Ok(Value::Str(format!(
+                                        "{:0width$b}",
+                                        n & mask,
+                                        width = *width as usize
+                                    )))
                                 }
-                                let mask = (1_i64 << width) - 1;
-                                Value::Str(format!(
-                                    "{:0width$b}",
-                                    n & mask,
-                                    width = *width as usize
-                                ))
                             }
-                            _ => panic!("binary() expects one or two integers"),
+                            _ => Err(RuntimeError::TypeError(
+                                "binary() expects one or two integers".to_string(),
+                            )),
                         },
                         "length" => {
                             if args.len() != 1 {
-                                panic!("length() expects one positional argument");
-                            }
-                            match &args[0] {
-                                Value::List(list) => Value::Int(list.borrow().len() as i64),
-                                Value::Str(s) => Value::Int(s.chars().count() as i64),
-                                _ => panic!("length() expects list or string"),
+                                Err(RuntimeError::TypeError(
+                                    "length() expects one positional argument".to_string(),
+                                ))
+                            } else {
+                                match &args[0] {
+                                    Value::List(list) => {
+                                        Ok(Value::Int(list.borrow().len() as i64))
+                                    }
+                                    Value::Str(s) => {
+                                        Ok(Value::Int(s.chars().count() as i64))
+                                    }
+                                    _ => Err(RuntimeError::TypeError(
+                                        "length() expects list or string".to_string(),
+                                    )),
+                                }
                             }
                         }
                         "freeze" => match args.as_slice() {
                             [Value::Dict(map)] => {
                                 let frozen = map.borrow().clone();
-                                Value::FrozenDict(Rc::new(frozen))
+                                Ok(Value::FrozenDict(Rc::new(frozen)))
                             }
-                            [Value::FrozenDict(map)] => Value::FrozenDict(map.clone()),
-                            _ => panic!("freeze() expects a dict"),
+                            [Value::FrozenDict(map)] => Ok(Value::FrozenDict(map.clone())),
+                            _ => Err(RuntimeError::TypeError(
+                                "freeze() expects a dict".to_string(),
+                            )),
                         },
                         "panic" => match args.as_slice() {
                             [Value::Str(msg)] => {
                                 eprintln!("{}", msg);
                                 process::exit(1);
                             }
-                            _ => panic!("panic() expects a string"),
+                            _ => Err(RuntimeError::TypeError(
+                                "panic() expects a string".to_string(),
+                            )),
                         },
                         "read_file" => match args.as_slice() {
                             [Value::Str(path)] => {
@@ -546,15 +570,23 @@ pub fn run(
                                     }
                                 }
                                 match fs::read_to_string(&path_buf) {
-                                    Ok(content) => Value::Str(content),
-                                    Err(_) => Value::Bool(false),
+                                    Ok(content) => Ok(Value::Str(content)),
+                                    Err(_) => Ok(Value::Bool(false)),
                                 }
                             }
-                            _ => panic!("read_file() expects a file path"),
+                            _ => Err(RuntimeError::TypeError(
+                                "read_file() expects a file path".to_string(),
+                            )),
                         },
-                        _ => panic!("unknown builtin: {}", name),
+                        _ => Err(RuntimeError::TypeError(format!(
+                            "unknown builtin: {}",
+                            name
+                        ))),
                     };
-                    stack.push(result);
+                    match result {
+                        Ok(val) => stack.push(val),
+                        Err(e) => break Err(e),
+                    }
                 }
                 Instr::Pop => {
                     stack.pop();

--- a/runtime/src/vm/tests.rs
+++ b/runtime/src/vm/tests.rs
@@ -95,3 +95,64 @@ fn assert_caught_in_block() {
     let result = run(&code, &funcs, &[]);
     assert!(result.is_ok());
 }
+
+#[test]
+fn hex_with_string_type_error() {
+    let code = vec![
+        Instr::PushStr("foo".to_string()),
+        Instr::CallBuiltin("hex".to_string(), 1),
+        Instr::Halt,
+    ];
+    let funcs = HashMap::new();
+    let result = run(&code, &funcs, &[]);
+    assert_eq!(
+        result,
+        Err(RuntimeError::TypeError("hex() expects one integer".to_string()))
+    );
+}
+
+#[test]
+fn binary_with_string_type_error() {
+    let code = vec![
+        Instr::PushStr("foo".to_string()),
+        Instr::CallBuiltin("binary".to_string(), 1),
+        Instr::Halt,
+    ];
+    let funcs = HashMap::new();
+    let result = run(&code, &funcs, &[]);
+    assert_eq!(
+        result,
+        Err(RuntimeError::TypeError("binary() expects one or two integers".to_string()))
+    );
+}
+
+#[test]
+fn binary_with_non_positive_width_type_error() {
+    let code = vec![
+        Instr::PushInt(5),
+        Instr::PushInt(0),
+        Instr::CallBuiltin("binary".to_string(), 2),
+        Instr::Halt,
+    ];
+    let funcs = HashMap::new();
+    let result = run(&code, &funcs, &[]);
+    assert_eq!(
+        result,
+        Err(RuntimeError::TypeError("binary() width must be positive".to_string()))
+    );
+}
+
+#[test]
+fn length_with_int_type_error() {
+    let code = vec![
+        Instr::PushInt(5),
+        Instr::CallBuiltin("length".to_string(), 1),
+        Instr::Halt,
+    ];
+    let funcs = HashMap::new();
+    let result = run(&code, &funcs, &[]);
+    assert_eq!(
+        result,
+        Err(RuntimeError::TypeError("length() expects list or string".to_string()))
+    );
+}


### PR DESCRIPTION
## Summary
- avoid panics in `hex`, `binary`, `length`, and other built-ins by returning `RuntimeError`s
- cover new error paths with unit tests

## Testing
- `cargo test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6898bc4f3f788323bcbdb3870dcff152