### PR TITLE
Centralize builtin dispatch with shared helper

### DIFF
--- a/bootstrap/interpreter.omg
+++ b/bootstrap/interpreter.omg
@@ -814,49 +814,11 @@ proc call_function(func_name, func, arg_values, env) {
         return false
     } elif func[0] == "builtin" {
         alloc name := func[1]
-        if name == "length" {
-            if length(arg_values) != 1 {
-                raise("RuntimeError: length() expects one positional argument")
-            }
-            return length(arg_values[0])
-        } elif name == "read_file" {
-            if length(arg_values) != 1 {
-                raise("RuntimeError: read_file() expects one positional argument")
-            }
-            return read_file(arg_values[0])
-        } elif name == "ascii" {
-            if length(arg_values) != 1 {
-                raise("RuntimeError: ascii() expects one positional argument")
-            }
-            return ascii(arg_values[0])
-        } elif name == "chr" {
-            if length(arg_values) != 1 {
-                raise("RuntimeError: chr() expects one positional argument")
-            }
-            return chr(arg_values[0])
-        } elif name == "freeze" {
-            if length(arg_values) != 1 {
-                raise("RuntimeError: freeze() expects one positional argument")
-            }
-            return freeze(arg_values[0])
-        } elif name == "raise" {
+        if name == "raise" {
             raise(arg_values[0])
             return false
-        } elif name == "hex" {
-            if length(arg_values) != 1 {
-                raise("RuntimeError: hex() expects one integer")
-            }
-            return hex(arg_values[0])
-        } elif name == "binary" {
-            if length(arg_values) == 1 {
-                return binary(arg_values[0])
-            } elif length(arg_values) == 2 {
-                return binary(arg_values[0], arg_values[1])
-            }
-            raise("RuntimeError: binary() expects one or two integers")
         }
-        raise("RuntimeError: Unknown builtin: " + name)
-        return false
+        return call_builtin(name, arg_values)
     } else {
         raise("TypeError: Not a function value")
         return false

--- a/omglang/compiler.py
+++ b/omglang/compiler.py
@@ -117,6 +117,7 @@ class Compiler:
             "length",
             "read_file",
             "freeze",
+            "call_builtin",
         }
 
     # ------------------------------------------------------------------

--- a/runtime/src/vm.rs
+++ b/runtime/src/vm.rs
@@ -16,6 +16,114 @@ struct Block {
     ret_depth: usize,
 }
 
+fn call_builtin(
+    name: &str,
+    args: &[Value],
+    env: &HashMap<String, Value>,
+    globals: &HashMap<String, Value>,
+) -> Result<Value, RuntimeError> {
+    match name {
+        "chr" => match args {
+            [Value::Int(i)] => Ok(Value::Str((*i as u8 as char).to_string())),
+            _ => Err(RuntimeError::TypeError("chr() expects one integer".to_string())),
+        },
+        "ascii" => match args {
+            [Value::Str(s)] if s.chars().count() == 1 => {
+                Ok(Value::Int(s.chars().next().unwrap() as i64))
+            }
+            _ => Err(RuntimeError::TypeError(
+                "ascii() expects a single character".to_string(),
+            )),
+        },
+        "hex" => match args {
+            [Value::Int(i)] => Ok(Value::Str(format!("{:x}", i))),
+            _ => Err(RuntimeError::TypeError("hex() expects one integer".to_string())),
+        },
+        "binary" => match args {
+            [Value::Int(n)] => Ok(Value::Str(format!("{:b}", n))),
+            [Value::Int(n), Value::Int(width)] => {
+                if *width <= 0 {
+                    Err(RuntimeError::TypeError(
+                        "binary() width must be positive".to_string(),
+                    ))
+                } else {
+                    let mask = (1_i64 << width) - 1;
+                    Ok(Value::Str(format!(
+                        "{:0width$b}",
+                        n & mask,
+                        width = *width as usize
+                    )))
+                }
+            }
+            _ => Err(RuntimeError::TypeError(
+                "binary() expects one or two integers".to_string(),
+            )),
+        },
+        "length" => {
+            if args.len() != 1 {
+                Err(RuntimeError::TypeError(
+                    "length() expects one positional argument".to_string(),
+                ))
+            } else {
+                match &args[0] {
+                    Value::List(list) => Ok(Value::Int(list.borrow().len() as i64)),
+                    Value::Str(s) => Ok(Value::Int(s.chars().count() as i64)),
+                    _ => Err(RuntimeError::TypeError(
+                        "length() expects list or string".to_string(),
+                    )),
+                }
+            }
+        }
+        "freeze" => match args {
+            [Value::Dict(map)] => {
+                let frozen = map.borrow().clone();
+                Ok(Value::FrozenDict(Rc::new(frozen)))
+            }
+            [Value::FrozenDict(map)] => Ok(Value::FrozenDict(map.clone())),
+            _ => Err(RuntimeError::TypeError("freeze() expects a dict".to_string())),
+        },
+        "panic" => match args {
+            [Value::Str(msg)] => {
+                eprintln!("{}", msg);
+                process::exit(1);
+            }
+            _ => Err(RuntimeError::TypeError("panic() expects a string".to_string())),
+        },
+        "read_file" => match args {
+            [Value::Str(path)] => {
+                let mut path_buf = PathBuf::from(path.replace("\\", "/"));
+                if path_buf.is_relative() {
+                    if let Some(Value::Str(cur)) = env
+                        .get("current_dir")
+                        .or_else(|| globals.get("current_dir"))
+                    {
+                        let base = PathBuf::from(cur.replace("\\", "/"));
+                        path_buf = base.join(path_buf);
+                    }
+                }
+                match fs::read_to_string(&path_buf) {
+                    Ok(content) => Ok(Value::Str(content)),
+                    Err(_) => Ok(Value::Bool(false)),
+                }
+            }
+            _ => Err(RuntimeError::TypeError("read_file() expects a file path".to_string())),
+        },
+        "call_builtin" => match args {
+            [Value::Str(inner), Value::List(list)] => {
+                let inner_args = list.borrow().clone();
+                call_builtin(inner, &inner_args, env, globals)
+            }
+            _ => Err(RuntimeError::TypeError(
+                "call_builtin() expects a name and argument list".to_string(),
+            )),
+        },
+        _ => Err(RuntimeError::TypeError(format!(
+            "unknown builtin: {}",
+            name
+        ))),
+    }
+}
+
 /// Execute bytecode on a stack-based virtual machine.
 pub fn run(
     code: &[Instr],
@@ -478,112 +586,7 @@ pub fn run(
                         args.push(stack.pop().unwrap());
                     }
                     args.reverse();
-                    let result: Result<Value, RuntimeError> = match name.as_str() {
-                        "chr" => match args.as_slice() {
-                            [Value::Int(i)] => Ok(Value::Str((*i as u8 as char).to_string())),
-                            _ => Err(RuntimeError::TypeError(
-                                "chr() expects one integer".to_string(),
-                            )),
-                        },
-                        "ascii" => match args.as_slice() {
-                            [Value::Str(s)] if s.chars().count() == 1 => {
-                                Ok(Value::Int(s.chars().next().unwrap() as i64))
-                            }
-                            _ => Err(RuntimeError::TypeError(
-                                "ascii() expects a single character".to_string(),
-                            )),
-                        },
-                        "hex" => match args.as_slice() {
-                            [Value::Int(i)] => Ok(Value::Str(format!("{:x}", i))),
-                            _ => Err(RuntimeError::TypeError(
-                                "hex() expects one integer".to_string(),
-                            )),
-                        },
-                        "binary" => match args.as_slice() {
-                            [Value::Int(n)] => Ok(Value::Str(format!("{:b}", n))),
-                            [Value::Int(n), Value::Int(width)] => {
-                                if *width <= 0 {
-                                    Err(RuntimeError::TypeError(
-                                        "binary() width must be positive".to_string(),
-                                    ))
-                                } else {
-                                    let mask = (1_i64 << width) - 1;
-                                    Ok(Value::Str(format!(
-                                        "{:0width$b}",
-                                        n & mask,
-                                        width = *width as usize
-                                    )))
-                                }
-                            }
-                            _ => Err(RuntimeError::TypeError(
-                                "binary() expects one or two integers".to_string(),
-                            )),
-                        },
-                        "length" => {
-                            if args.len() != 1 {
-                                Err(RuntimeError::TypeError(
-                                    "length() expects one positional argument".to_string(),
-                                ))
-                            } else {
-                                match &args[0] {
-                                    Value::List(list) => {
-                                        Ok(Value::Int(list.borrow().len() as i64))
-                                    }
-                                    Value::Str(s) => {
-                                        Ok(Value::Int(s.chars().count() as i64))
-                                    }
-                                    _ => Err(RuntimeError::TypeError(
-                                        "length() expects list or string".to_string(),
-                                    )),
-                                }
-                            }
-                        }
-                        "freeze" => match args.as_slice() {
-                            [Value::Dict(map)] => {
-                                let frozen = map.borrow().clone();
-                                Ok(Value::FrozenDict(Rc::new(frozen)))
-                            }
-                            [Value::FrozenDict(map)] => Ok(Value::FrozenDict(map.clone())),
-                            _ => Err(RuntimeError::TypeError(
-                                "freeze() expects a dict".to_string(),
-                            )),
-                        },
-                        "panic" => match args.as_slice() {
-                            [Value::Str(msg)] => {
-                                eprintln!("{}", msg);
-                                process::exit(1);
-                            }
-                            _ => Err(RuntimeError::TypeError(
-                                "panic() expects a string".to_string(),
-                            )),
-                        },
-                        "read_file" => match args.as_slice() {
-                            [Value::Str(path)] => {
-                                let mut path_buf = PathBuf::from(path.replace("\\", "/"));
-                                if path_buf.is_relative() {
-                                    if let Some(Value::Str(cur)) = env
-                                        .get("current_dir")
-                                        .or_else(|| globals.get("current_dir"))
-                                    {
-                                        let base = PathBuf::from(cur.replace("\\", "/"));
-                                        path_buf = base.join(path_buf);
-                                    }
-                                }
-                                match fs::read_to_string(&path_buf) {
-                                    Ok(content) => Ok(Value::Str(content)),
-                                    Err(_) => Ok(Value::Bool(false)),
-                                }
-                            }
-                            _ => Err(RuntimeError::TypeError(
-                                "read_file() expects a file path".to_string(),
-                            )),
-                        },
-                        _ => Err(RuntimeError::TypeError(format!(
-                            "unknown builtin: {}",
-                            name
-                        ))),
-                    };
-                    match result {
+                    match call_builtin(name, &args, &env, &globals) {
                         Ok(val) => stack.push(val),
                         Err(e) => break Err(e),
                     }

--- a/runtime/src/vm/tests.rs
+++ b/runtime/src/vm/tests.rs
@@ -156,3 +156,20 @@ fn length_with_int_type_error() {
         Err(RuntimeError::TypeError("length() expects list or string".to_string()))
     );
 }
+
+#[test]
+fn call_builtin_dispatches_hex() {
+    let code = vec![
+        Instr::PushStr("hex".to_string()),
+        Instr::PushInt(255),
+        Instr::BuildList(1),
+        Instr::CallBuiltin("call_builtin".to_string(), 2),
+        Instr::PushStr("ff".to_string()),
+        Instr::Eq,
+        Instr::Assert,
+        Instr::Halt,
+    ];
+    let funcs = HashMap::new();
+    let result = run(&code, &funcs, &[]);
+    assert!(result.is_ok());
+}


### PR DESCRIPTION
## Summary
- Factor out builtin handling into a shared `call_builtin` helper
- Route VM bytecode and self-hosted interpreter through `call_builtin`
- Add coverage for indirect builtin invocation via `call_builtin`

## Testing
- `cargo test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6898d7bb96cc832382e3093b3af50e46