### PR TITLE
Unify VM raise opcode via ErrorKind operand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 Ordered from most recent at the top to oldest at the bottom.
 
+## [0.1.3] - 2025-08-10
+
+### Changed
+- Consolidated multiple raise opcodes into a single `RAISE <kind>` instruction driven by a new compact `ErrorKind` enum.
+- Updated compiler, VM, and disassembler to encode error kinds as a byte operand and construct `RuntimeError` variants centrally.
+- Added VM invariant error on stack underflow for `RAISE`.
+
+### Added
+- Backward decoding support for legacy raise opcodes (47–51) for one release.
+- Tests covering all raise kinds and stack underflow behaviour.
+
 ## [0.1.2] - 2025-08-10
 
 ### Added

--- a/omglang/compiler.py
+++ b/omglang/compiler.py
@@ -75,16 +75,32 @@ OPCODES: dict[str, int] = {
     "SETUP_EXCEPT": 44,
     "POP_BLOCK": 45,
     "RAISE": 46,
-    "RAISE_SYNTAX_ERROR": 47,
-    "RAISE_TYPE_ERROR": 48,
-    "RAISE_UNDEF_IDENT_ERROR": 49,
-    "RAISE_VALUE_ERROR": 50,
-    "RAISE_MODULE_IMPORT_ERROR": 51,
 }
 
 # Reverse-mapped opcode mnemonics
 REV_OPCODES: dict[int, str] = {v: k for k, v in OPCODES.items()}
 
+# Error kind mapping for RAISE instruction
+ERROR_KIND_TO_CODE = {
+    "Generic": 0,
+    "Syntax": 1,
+    "Type": 2,
+    "UndefinedIdent": 3,
+    "Value": 4,
+    "ModuleImport": 5,
+}
+CODE_TO_ERROR_KIND = {v: k for k, v in ERROR_KIND_TO_CODE.items()}
+
+# Mapping from raise helper function names to error kinds
+ERROR_NAME_TO_KIND = {
+    "panic": "Generic",
+    "raise": "Generic",
+    "_omg_vm_syntax_error_handle": "Syntax",
+    "_omg_vm_type_error_handle": "Type",
+    "_omg_vm_undef_ident_error_handle": "UndefinedIdent",
+    "_omg_vm_value_error_handle": "Value",
+    "_omg_vm_module_import_error_handle": "ModuleImport",
+}
 # Bytecode header
 MAGIC_HEADER = b"OMGB"
 
@@ -149,6 +165,18 @@ class Compiler:
         op, _ = self.code[idx]
         self.code[idx] = (op, target)
 
+    def compile_raise_call(self, name: str, args: List[tuple]) -> bool:
+        """Compile special raise helper calls into RAISE instructions."""
+        kind = ERROR_NAME_TO_KIND.get(name)
+        if kind is None:
+            return False
+        if args:
+            self.compile_expr(args[0])
+        else:
+            self.emit("PUSH_STR", "")
+        self.emit("RAISE", kind)
+        return True
+
     # ------------------------------------------------------------------
     # Compilation entry points
     # ------------------------------------------------------------------
@@ -207,6 +235,8 @@ class Compiler:
                 out.extend(struct.pack("<I", len(sb)))
                 out.extend(sb)
                 out.extend(struct.pack("<I", argc))
+            elif op == "RAISE" and isinstance(arg, str):
+                out.append(ERROR_KIND_TO_CODE[arg])
             elif op in {"JUMP", "JUMP_IF_FALSE", "SETUP_EXCEPT"} and isinstance(arg, int):
                 out.extend(struct.pack("<I", arg))
             # Remaining instructions carry no operands.
@@ -404,43 +434,7 @@ class Compiler:
             func_node, args = node[1], node[2]
             if func_node[0] == "ident":
                 name = func_node[1]
-                if name in {"panic", "raise"}:
-                    if args:
-                        self.compile_expr(args[0])
-                    else:
-                        self.emit("PUSH_STR", "")
-                    self.emit("RAISE")
-                elif name == "_omg_vm_syntax_error_handle":
-                    if args:
-                        self.compile_expr(args[0])
-                    else:
-                        self.emit("PUSH_STR", "")
-                    self.emit("RAISE_SYNTAX_ERROR")
-                elif name == "_omg_vm_type_error_handle":
-                    if args:
-                        self.compile_expr(args[0])
-                    else:
-                        self.emit("PUSH_STR", "")
-                    self.emit("RAISE_TYPE_ERROR")
-                elif name == "_omg_vm_undef_ident_error_handle":
-                    if args:
-                        self.compile_expr(args[0])
-                    else:
-                        self.emit("PUSH_STR", "")
-                    self.emit("RAISE_UNDEF_IDENT_ERROR")
-                elif name == "_omg_vm_value_error_handle":
-                    if args:
-                        self.compile_expr(args[0])
-                    else:
-                        self.emit("PUSH_STR", "")
-                    self.emit("RAISE_VALUE_ERROR")
-                elif name == "_omg_vm_module_import_error_handle":
-                    if args:
-                        self.compile_expr(args[0])
-                    else:
-                        self.emit("PUSH_STR", "")
-                    self.emit("RAISE_MODULE_IMPORT_ERROR")
-                else:
+                if not self.compile_raise_call(name, args):
                     for arg in args:
                         self.compile_expr(arg)
                     if name in self.builtins:
@@ -571,6 +565,10 @@ def disassemble(data: bytes) -> str:
             argc = struct.unpack_from("<I", data, idx)[0]
             idx += 4
             lines.append(f"BUILTIN {s} {argc}")
+        elif name == "RAISE":
+            kind = data[idx]
+            idx += 1
+            lines.append(f"RAISE {CODE_TO_ERROR_KIND.get(kind, str(kind))}")
         elif name in {"JUMP", "JUMP_IF_FALSE", "SETUP_EXCEPT"}:
             (t,) = struct.unpack_from("<I", data, idx)
             idx += 4

--- a/omglang/tests/test_raise_bytecode.py
+++ b/omglang/tests/test_raise_bytecode.py
@@ -1,0 +1,21 @@
+import pytest
+from omglang.compiler import compile_source, disassemble
+
+@pytest.mark.parametrize(
+    "call, kind",
+    [
+        ("panic(\"boom\")", "Generic"),
+        ("raise(\"boom\")", "Generic"),
+        ("_omg_vm_syntax_error_handle(\"boom\")", "Syntax"),
+        ("_omg_vm_type_error_handle(\"boom\")", "Type"),
+        ("_omg_vm_undef_ident_error_handle(\"boom\")", "UndefinedIdent"),
+        ("_omg_vm_value_error_handle(\"boom\")", "Value"),
+        ("_omg_vm_module_import_error_handle(\"boom\")", "ModuleImport"),
+    ],
+)
+def test_raise_compiles_to_raise_kind(call: str, kind: str) -> None:
+    bc = compile_source(call)
+    lines = disassemble(bc).splitlines()
+    assert "PUSH_STR boom" in lines
+    assert f"RAISE {kind}" in lines
+    assert lines.index("PUSH_STR boom") < lines.index(f"RAISE {kind}")

--- a/omglang/tests/test_raise_bytecode.py
+++ b/omglang/tests/test_raise_bytecode.py
@@ -1,5 +1,9 @@
+"""
+Test Errors.
+"""
 import pytest
 from omglang.compiler import compile_source, disassemble
+
 
 @pytest.mark.parametrize(
     "call, kind",
@@ -14,6 +18,9 @@ from omglang.compiler import compile_source, disassemble
     ],
 )
 def test_raise_compiles_to_raise_kind(call: str, kind: str) -> None:
+    """
+    Test raising error kind.
+    """
     bc = compile_source(call)
     lines = disassemble(bc).splitlines()
     assert "PUSH_STR boom" in lines

--- a/runtime/src/vm.rs
+++ b/runtime/src/vm.rs
@@ -631,29 +631,17 @@ pub fn run(
                 Instr::PopBlock => {
                     block_stack.pop();
                 }
-                Instr::Raise => {
-                    let msg = stack.pop().unwrap().to_string();
-                    break Err(RuntimeError::Raised(msg));
-                }
-                Instr::RaiseSyntaxError => {
-                    let msg = stack.pop().unwrap().to_string();
-                    break Err(RuntimeError::SyntaxError(msg));
-                }
-                Instr::RaiseTypeError => {
-                    let msg = stack.pop().unwrap().to_string();
-                    break Err(RuntimeError::TypeError(msg));
-                }
-                Instr::RaiseUndefinedIdentError => {
-                    let msg = stack.pop().unwrap().to_string();
-                    break Err(RuntimeError::UndefinedIdentError(msg));
-                }
-                Instr::RaiseValueError => {
-                    let msg = stack.pop().unwrap().to_string();
-                    break Err(RuntimeError::ValueError(msg));
-                }
-                Instr::RaiseModuleImportError => {
-                    let msg = stack.pop().unwrap().to_string();
-                    break Err(RuntimeError::ModuleImportError(msg))
+                Instr::Raise(kind) => {
+                    let msg_val = match stack.pop() {
+                        Some(v) => v,
+                        None => {
+                            break Err(RuntimeError::VmInvariant(
+                                "stack underflow on RAISE".to_string(),
+                            ))
+                        }
+                    };
+                    let msg = msg_val.to_string();
+                    break Err(kind.into_runtime(msg));
                 }
             }
             break Ok(());

--- a/runtime/src/vm/tests.rs
+++ b/runtime/src/vm/tests.rs
@@ -1,6 +1,6 @@
 use super::*;
 use crate::bytecode::{Function, Instr};
-use crate::error::RuntimeError;
+use crate::error::{RuntimeError, ErrorKind};
 use std::collections::HashMap;
 
 #[test]
@@ -52,7 +52,7 @@ fn raise_caught_in_caller() {
         Instr::Halt,
         // boom function
         Instr::PushStr("boom".to_string()),
-        Instr::Raise,
+        Instr::Raise(ErrorKind::Generic),
         Instr::Ret,
     ];
     let result = run(&code, &funcs, &[]);
@@ -63,7 +63,7 @@ fn raise_caught_in_caller() {
 fn uncaught_raise_surfaces() {
     let code = vec![
         Instr::PushStr("boom".to_string()),
-        Instr::Raise,
+        Instr::Raise(ErrorKind::Generic),
         Instr::Halt,
     ];
     let funcs = HashMap::new();
@@ -75,7 +75,7 @@ fn uncaught_raise_surfaces() {
 fn uncaught_syntax_error_surfaces() {
     let code = vec![
         Instr::PushStr("boom".to_string()),
-        Instr::RaiseSyntaxError,
+        Instr::Raise(ErrorKind::Syntax),
         Instr::Halt,
     ];
     let funcs = HashMap::new();
@@ -90,7 +90,7 @@ fn uncaught_syntax_error_surfaces() {
 fn uncaught_type_error_surfaces() {
     let code = vec![
         Instr::PushStr("boom".to_string()),
-        Instr::RaiseTypeError,
+        Instr::Raise(ErrorKind::Type),
         Instr::Halt,
     ];
     let funcs = HashMap::new();
@@ -105,7 +105,7 @@ fn uncaught_type_error_surfaces() {
 fn uncaught_undef_ident_error_surfaces() {
     let code = vec![
         Instr::PushStr("boom".to_string()),
-        Instr::RaiseUndefinedIdentError,
+        Instr::Raise(ErrorKind::UndefinedIdent),
         Instr::Halt,
     ];
     let funcs = HashMap::new();
@@ -113,6 +113,17 @@ fn uncaught_undef_ident_error_surfaces() {
     assert_eq!(
         result,
         Err(RuntimeError::UndefinedIdentError("boom".to_string()))
+    );
+}
+
+#[test]
+fn raise_stack_underflow_errors() {
+    let code = vec![Instr::Raise(ErrorKind::Generic), Instr::Halt];
+    let funcs = HashMap::new();
+    let result = run(&code, &funcs, &[]);
+    assert_eq!(
+        result,
+        Err(RuntimeError::VmInvariant("stack underflow on RAISE".to_string()))
     );
 }
 

--- a/scripts/verify_omgb_file_bytes.py
+++ b/scripts/verify_omgb_file_bytes.py
@@ -98,6 +98,11 @@ def verify_interpreter(interp_bin: str) -> None:
             bname, idx = _read_str(data, idx)
             argc, idx = _read_u32(data, idx)
             arg = (bname, argc)
+        elif name == "RAISE":
+            if idx >= len(data):
+                raise ValueError("error kind beyond end of file")
+            arg = data[idx]
+            idx += 1
         elif name in {"LOAD", "STORE", "CALL", "TCALL", "ATTR", "STORE_ATTR"}:
             arg, idx = _read_str(data, idx)
         # other opcodes carry no immediate argument

--- a/spec/OMG_ERRORS.md
+++ b/spec/OMG_ERRORS.md
@@ -6,6 +6,21 @@ Please note this list is not exhaustive, for all errors please see the original 
 
 ---
 
+### VM Error Kinds
+
+The native runtime uses a single `RAISE <kind>` instruction where `<kind>` maps to a specific `RuntimeError` variant. Supported kinds are:
+
+- `Generic`
+- `Syntax`
+- `Type`
+- `UndefinedIdent`
+- `Value`
+- `ModuleImport`
+
+These cover the common error categories raised by the VM.
+
+---
+
 ## 1. Missing Script Header
 
 If the required `;;;omg` header is missing, the interpreter raises:


### PR DESCRIPTION
## Summary
- consolidate multiple raise opcodes into single `RAISE <kind>` using new `ErrorKind` enum
- update compiler and disassembler to encode/decode error kinds and emit unified `RAISE`
- add VM invariant check for stack underflow and tests covering each raise kind

## Testing
- `cargo test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68990f607d9c8323a3bafc5463232343