### PR TITLE
Validate slice bounds in VM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,9 +24,10 @@ Ordered from most recent at the top to oldest at the bottom.
 
 ### Fixed
 - Centralized `call_builtin` helper eliminates scattered implementations across the runtime.
-- Narrower error handling eliminates relying on generic string-based `raise` which was resulting in prefixed errors e.g. `RuntimeError: SyntaxError: Unxepected <symbol>...`, errors are now correctly defined according to their type. Generic `raise()` has been retained for special cases. 
+- Narrower error handling eliminates relying on generic string-based `raise` which was resulting in prefixed errors e.g. `RuntimeError: SyntaxError: Unxepected <symbol>...`, errors are now correctly defined according to their type. Generic `raise()` has been retained for special cases.
 - Refactored basename extraction in bootstrap interpreter's `import_module` to avoid negative string indexing when module paths lack directory separators.
 - Guarded `dirname` and `run_file_with_args` against negative string indexing so modules in the current directory import and execute without errors.
+- Validated slice indices in the VM, returning `IndexError` for out-of-range or invalid ranges instead of panicking.
 
 ## [0.1.1] - 2025-08-08
 

--- a/runtime/src/vm.rs
+++ b/runtime/src/vm.rs
@@ -433,24 +433,61 @@ pub fn run(
                 }
                 Instr::Slice => {
                     let end_val = pop(&mut stack)?;
-                    let start = pop(&mut stack)?.as_int() as usize;
+                    let start_val = pop(&mut stack)?;
                     let base = pop(&mut stack)?;
+                    let start_i64 = start_val.as_int();
                     match base {
                         Value::List(list) => {
                             let list_ref = list.borrow();
-                            let end = match end_val {
-                                Value::None => list_ref.len(),
-                                v => v.as_int() as usize,
+                            let len = list_ref.len();
+                            if start_i64 < 0 {
+                                break Err(RuntimeError::IndexError(
+                                    "Slice indices out of bounds!".to_string(),
+                                ));
+                            }
+                            let start = start_i64 as usize;
+                            let end_i64 = match end_val {
+                                Value::None => len as i64,
+                                v => v.as_int(),
                             };
+                            if end_i64 < 0 {
+                                break Err(RuntimeError::IndexError(
+                                    "Slice indices out of bounds!".to_string(),
+                                ));
+                            }
+                            let end = end_i64 as usize;
+                            if start > end || end > len {
+                                break Err(RuntimeError::IndexError(
+                                    "Slice indices out of bounds!".to_string(),
+                                ));
+                            }
                             let slice = list_ref[start..end].to_vec();
                             stack.push(Value::List(Rc::new(RefCell::new(slice))));
                         }
                         Value::Str(s) => {
                             let chars: Vec<char> = s.chars().collect();
-                            let end = match end_val {
-                                Value::None => chars.len(),
-                                v => v.as_int() as usize,
+                            let len = chars.len();
+                            if start_i64 < 0 {
+                                break Err(RuntimeError::IndexError(
+                                    "Slice indices out of bounds!".to_string(),
+                                ));
+                            }
+                            let start = start_i64 as usize;
+                            let end_i64 = match end_val {
+                                Value::None => len as i64,
+                                v => v.as_int(),
                             };
+                            if end_i64 < 0 {
+                                break Err(RuntimeError::IndexError(
+                                    "Slice indices out of bounds!".to_string(),
+                                ));
+                            }
+                            let end = end_i64 as usize;
+                            if start > end || end > len {
+                                break Err(RuntimeError::IndexError(
+                                    "Slice indices out of bounds!".to_string(),
+                                ));
+                            }
                             let slice: String = chars[start..end].iter().collect();
                             stack.push(Value::Str(slice));
                         }

--- a/runtime/src/vm/tests.rs
+++ b/runtime/src/vm/tests.rs
@@ -80,10 +80,7 @@ fn uncaught_syntax_error_surfaces() {
     ];
     let funcs = HashMap::new();
     let result = run(&code, &funcs, &[]);
-    assert_eq!(
-        result,
-        Err(RuntimeError::SyntaxError("boom".to_string()))
-    );
+    assert_eq!(result, Err(RuntimeError::SyntaxError("boom".to_string())));
 }
 
 #[test]
@@ -95,10 +92,7 @@ fn uncaught_type_error_surfaces() {
     ];
     let funcs = HashMap::new();
     let result = run(&code, &funcs, &[]);
-    assert_eq!(
-        result,
-        Err(RuntimeError::TypeError("boom".to_string()))
-    );
+    assert_eq!(result, Err(RuntimeError::TypeError("boom".to_string())));
 }
 
 #[test]
@@ -123,7 +117,9 @@ fn raise_stack_underflow_errors() {
     let result = run(&code, &funcs, &[]);
     assert_eq!(
         result,
-        Err(RuntimeError::VmInvariant("stack underflow on RAISE".to_string()))
+        Err(RuntimeError::VmInvariant(
+            "stack underflow on RAISE".to_string()
+        ))
     );
 }
 
@@ -163,7 +159,9 @@ fn hex_with_string_type_error() {
     let result = run(&code, &funcs, &[]);
     assert_eq!(
         result,
-        Err(RuntimeError::TypeError("hex() expects one integer (arity mismatch)".to_string()))
+        Err(RuntimeError::TypeError(
+            "hex() expects one integer (arity mismatch)".to_string()
+        ))
     );
 }
 
@@ -178,7 +176,9 @@ fn binary_with_string_type_error() {
     let result = run(&code, &funcs, &[]);
     assert_eq!(
         result,
-        Err(RuntimeError::TypeError("binary() expects one or two integers (arity mismatch)".to_string()))
+        Err(RuntimeError::TypeError(
+            "binary() expects one or two integers (arity mismatch)".to_string()
+        ))
     );
 }
 
@@ -194,7 +194,9 @@ fn binary_with_non_positive_width_type_error() {
     let result = run(&code, &funcs, &[]);
     assert_eq!(
         result,
-        Err(RuntimeError::ValueError("binary() width must be positive".to_string()))
+        Err(RuntimeError::ValueError(
+            "binary() width must be positive".to_string()
+        ))
     );
 }
 
@@ -209,7 +211,9 @@ fn length_with_int_type_error() {
     let result = run(&code, &funcs, &[]);
     assert_eq!(
         result,
-        Err(RuntimeError::TypeError("length() expects list or string (type mismatch)".to_string()))
+        Err(RuntimeError::TypeError(
+            "length() expects list or string (type mismatch)".to_string()
+        ))
     );
 }
 
@@ -277,5 +281,43 @@ fn call_value_unknown_function_errors() {
     assert_eq!(
         result,
         Err(RuntimeError::UndefinedIdentError("foo".to_string()))
+    );
+}
+
+#[test]
+fn list_slice_with_invalid_bounds_errors() {
+    let code = vec![
+        Instr::BuildList(0),
+        Instr::PushInt(1),
+        Instr::PushInt(0),
+        Instr::Slice,
+        Instr::Halt,
+    ];
+    let funcs = HashMap::new();
+    let result = run(&code, &funcs, &[]);
+    assert_eq!(
+        result,
+        Err(RuntimeError::IndexError(
+            "Slice indices out of bounds!".to_string()
+        ))
+    );
+}
+
+#[test]
+fn string_slice_with_invalid_bounds_errors() {
+    let code = vec![
+        Instr::PushStr("ab".to_string()),
+        Instr::PushInt(0),
+        Instr::PushInt(3),
+        Instr::Slice,
+        Instr::Halt,
+    ];
+    let funcs = HashMap::new();
+    let result = run(&code, &funcs, &[]);
+    assert_eq!(
+        result,
+        Err(RuntimeError::IndexError(
+            "Slice indices out of bounds!".to_string()
+        ))
     );
 }


### PR DESCRIPTION
## Summary
- guard list and string slicing against invalid ranges, raising `IndexError`
- add regression tests for invalid slice bounds
- document slice index validation in changelog

## Testing
- `cargo test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68992f76530c8323ae878d2ee143bbd9