### PR TITLE
refactor: modularize VM instruction handlers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 Ordered from most recent at the top to oldest at the bottom.
 
+## [0.1.3] - 2025-08-10
+
+### Changed
+- Refactored VM instruction handling into `ops_arith`, `ops_struct`, and `ops_control` modules for clarity.
+
 ## [0.1.2] - 2025-08-10
 
 ### Added

--- a/runtime/src/vm/ops_arith.rs
+++ b/runtime/src/vm/ops_arith.rs
@@ -1,0 +1,196 @@
+use crate::error::RuntimeError;
+use crate::value::Value;
+
+use super::pop;
+
+/// Handle the `ADD` instruction.
+pub fn handle_add(stack: &mut Vec<Value>) -> Result<(), RuntimeError> {
+    let b = pop(stack)?;
+    let a = pop(stack)?;
+    match (a, b) {
+        (Value::Str(sa), Value::Str(sb)) => stack.push(Value::Str(sa + &sb)),
+        (Value::Str(sa), v) => stack.push(Value::Str(sa + &v.to_string())),
+        (v, Value::Str(sb)) => stack.push(Value::Str(v.to_string() + &sb)),
+        (Value::List(la), Value::List(lb)) => {
+            {
+                let mut la_mut = la.borrow_mut();
+                la_mut.extend(lb.borrow().iter().cloned());
+            }
+            stack.push(Value::List(la));
+        }
+        (a, b) => stack.push(Value::Int(a.as_int() + b.as_int())),
+    }
+    Ok(())
+}
+
+/// Handle the `SUB` instruction.
+pub fn handle_sub(stack: &mut Vec<Value>) -> Result<(), RuntimeError> {
+    let b = pop(stack)?.as_int();
+    let a = pop(stack)?.as_int();
+    stack.push(Value::Int(a - b));
+    Ok(())
+}
+
+/// Handle the `MUL` instruction.
+pub fn handle_mul(stack: &mut Vec<Value>) -> Result<(), RuntimeError> {
+    let b = pop(stack)?.as_int();
+    let a = pop(stack)?.as_int();
+    stack.push(Value::Int(a.checked_mul(b).unwrap_or(0)));
+    Ok(())
+}
+
+/// Handle the `DIV` instruction.
+pub fn handle_div(stack: &mut Vec<Value>) -> Result<(), RuntimeError> {
+    let b = pop(stack)?.as_int();
+    if b == 0 {
+        return Err(RuntimeError::ZeroDivisionError);
+    }
+    let a = pop(stack)?.as_int();
+    stack.push(Value::Int(a / b));
+    Ok(())
+}
+
+/// Handle the `MOD` instruction.
+pub fn handle_mod(stack: &mut Vec<Value>) -> Result<(), RuntimeError> {
+    let b = pop(stack)?.as_int();
+    if b == 0 {
+        return Err(RuntimeError::ZeroDivisionError);
+    }
+    let a = pop(stack)?.as_int();
+    stack.push(Value::Int(a % b));
+    Ok(())
+}
+
+/// Handle the `EQ` instruction.
+pub fn handle_eq(stack: &mut Vec<Value>) -> Result<(), RuntimeError> {
+    let b = pop(stack)?.to_string();
+    let a = pop(stack)?.to_string();
+    stack.push(Value::Bool(a == b));
+    Ok(())
+}
+
+/// Handle the `NE` instruction.
+pub fn handle_ne(stack: &mut Vec<Value>) -> Result<(), RuntimeError> {
+    let b = pop(stack)?.to_string();
+    let a = pop(stack)?.to_string();
+    stack.push(Value::Bool(a != b));
+    Ok(())
+}
+
+/// Handle the `LT` instruction.
+pub fn handle_lt(stack: &mut Vec<Value>) -> Result<(), RuntimeError> {
+    let b = pop(stack)?;
+    let a = pop(stack)?;
+    let res = match (&a, &b) {
+        (Value::Str(sa), Value::Str(sb)) => sa < sb,
+        _ => a.as_int() < b.as_int(),
+    };
+    stack.push(Value::Bool(res));
+    Ok(())
+}
+
+/// Handle the `LE` instruction.
+pub fn handle_le(stack: &mut Vec<Value>) -> Result<(), RuntimeError> {
+    let b = pop(stack)?;
+    let a = pop(stack)?;
+    let res = match (&a, &b) {
+        (Value::Str(sa), Value::Str(sb)) => sa <= sb,
+        _ => a.as_int() <= b.as_int(),
+    };
+    stack.push(Value::Bool(res));
+    Ok(())
+}
+
+/// Handle the `GT` instruction.
+pub fn handle_gt(stack: &mut Vec<Value>) -> Result<(), RuntimeError> {
+    let b = pop(stack)?;
+    let a = pop(stack)?;
+    let res = match (&a, &b) {
+        (Value::Str(sa), Value::Str(sb)) => sa > sb,
+        _ => a.as_int() > b.as_int(),
+    };
+    stack.push(Value::Bool(res));
+    Ok(())
+}
+
+/// Handle the `GE` instruction.
+pub fn handle_ge(stack: &mut Vec<Value>) -> Result<(), RuntimeError> {
+    let b = pop(stack)?;
+    let a = pop(stack)?;
+    let res = match (&a, &b) {
+        (Value::Str(sa), Value::Str(sb)) => sa >= sb,
+        _ => a.as_int() >= b.as_int(),
+    };
+    stack.push(Value::Bool(res));
+    Ok(())
+}
+
+/// Handle the `BAND` instruction.
+pub fn handle_band(stack: &mut Vec<Value>) -> Result<(), RuntimeError> {
+    let b = pop(stack)?.as_int();
+    let a = pop(stack)?.as_int();
+    stack.push(Value::Int(a & b));
+    Ok(())
+}
+
+/// Handle the `BOR` instruction.
+pub fn handle_bor(stack: &mut Vec<Value>) -> Result<(), RuntimeError> {
+    let b = pop(stack)?.as_int();
+    let a = pop(stack)?.as_int();
+    stack.push(Value::Int(a | b));
+    Ok(())
+}
+
+/// Handle the `BXOR` instruction.
+pub fn handle_bxor(stack: &mut Vec<Value>) -> Result<(), RuntimeError> {
+    let b = pop(stack)?.as_int();
+    let a = pop(stack)?.as_int();
+    stack.push(Value::Int(a ^ b));
+    Ok(())
+}
+
+/// Handle the `SHL` instruction.
+pub fn handle_shl(stack: &mut Vec<Value>) -> Result<(), RuntimeError> {
+    let b = pop(stack)?.as_int() as u32;
+    let a = pop(stack)?.as_int();
+    stack.push(Value::Int(a << b));
+    Ok(())
+}
+
+/// Handle the `SHR` instruction.
+pub fn handle_shr(stack: &mut Vec<Value>) -> Result<(), RuntimeError> {
+    let b = pop(stack)?.as_int() as u32;
+    let a = pop(stack)?.as_int();
+    stack.push(Value::Int(a >> b));
+    Ok(())
+}
+
+/// Handle the `AND` instruction.
+pub fn handle_and(stack: &mut Vec<Value>) -> Result<(), RuntimeError> {
+    let b = pop(stack)?.as_bool();
+    let a = pop(stack)?.as_bool();
+    stack.push(Value::Bool(a && b));
+    Ok(())
+}
+
+/// Handle the `OR` instruction.
+pub fn handle_or(stack: &mut Vec<Value>) -> Result<(), RuntimeError> {
+    let b = pop(stack)?.as_bool();
+    let a = pop(stack)?.as_bool();
+    stack.push(Value::Bool(a || b));
+    Ok(())
+}
+
+/// Handle the `NOT` instruction.
+pub fn handle_not(stack: &mut Vec<Value>) -> Result<(), RuntimeError> {
+    let v = pop(stack)?.as_int();
+    stack.push(Value::Int(!v));
+    Ok(())
+}
+
+/// Handle the `NEG` instruction.
+pub fn handle_neg(stack: &mut Vec<Value>) -> Result<(), RuntimeError> {
+    let v = pop(stack)?.as_int();
+    stack.push(Value::Int(-v));
+    Ok(())
+}

--- a/runtime/src/vm/ops_control.rs
+++ b/runtime/src/vm/ops_control.rs
@@ -1,0 +1,220 @@
+use std::collections::HashMap;
+
+use crate::bytecode::Function;
+use crate::error::{ErrorKind, RuntimeError};
+use crate::value::Value;
+
+use super::{call_builtin, pop, Block};
+
+/// Handle the `ASSERT` instruction.
+pub fn handle_assert(stack: &mut Vec<Value>) -> Result<(), RuntimeError> {
+    let cond = pop(stack)?.as_bool();
+    if !cond {
+        return Err(RuntimeError::AssertionError);
+    }
+    Ok(())
+}
+
+/// Handle the `CALLVALUE` instruction.
+pub fn handle_call_value(
+    argc: usize,
+    stack: &mut Vec<Value>,
+    funcs: &HashMap<String, Function>,
+    env_stack: &mut Vec<HashMap<String, Value>>,
+    ret_stack: &mut Vec<usize>,
+    env: &mut HashMap<String, Value>,
+    pc: &mut usize,
+    advance_pc: &mut bool,
+) -> Result<(), RuntimeError> {
+    let mut args_vec: Vec<Value> = Vec::new();
+    for _ in 0..argc {
+        args_vec.push(pop(stack)?);
+    }
+    args_vec.reverse();
+    let func_val = pop(stack)?;
+    if let Value::Str(name) = func_val {
+        if let Some(func) = funcs.get(&name) {
+            let mut new_env = HashMap::new();
+            for param in func.params.iter().rev() {
+                let arg = args_vec.pop().unwrap();
+                new_env.insert(param.clone(), arg);
+            }
+            env_stack.push(std::mem::take(env));
+            ret_stack.push(*pc + 1);
+            *env = new_env;
+            *pc = func.address;
+            *advance_pc = false;
+            Ok(())
+        } else {
+            Err(RuntimeError::UndefinedIdentError(name))
+        }
+    } else {
+        Err(RuntimeError::TypeError(
+            "Call value expects function name".to_string(),
+        ))
+    }
+}
+
+/// Handle the `PUSHNONE` instruction.
+pub fn handle_push_none(stack: &mut Vec<Value>) {
+    stack.push(Value::None);
+}
+
+/// Handle the `JUMP` instruction.
+pub fn handle_jump(pc: &mut usize, target: usize, advance_pc: &mut bool) {
+    *pc = target;
+    *advance_pc = false;
+}
+
+/// Handle the `JUMPIFFALSE` instruction.
+pub fn handle_jump_if_false(
+    stack: &mut Vec<Value>,
+    pc: &mut usize,
+    target: usize,
+    advance_pc: &mut bool,
+) -> Result<(), RuntimeError> {
+    let cond = pop(stack)?.as_bool();
+    if !cond {
+        *pc = target;
+        *advance_pc = false;
+    }
+    Ok(())
+}
+
+/// Handle the `CALL` instruction.
+pub fn handle_call(
+    name: &str,
+    funcs: &HashMap<String, Function>,
+    stack: &mut Vec<Value>,
+    env: &mut HashMap<String, Value>,
+    env_stack: &mut Vec<HashMap<String, Value>>,
+    ret_stack: &mut Vec<usize>,
+    pc: &mut usize,
+    advance_pc: &mut bool,
+) -> Result<(), RuntimeError> {
+    if let Some(func) = funcs.get(name) {
+        let mut new_env = HashMap::new();
+        for param in func.params.iter().rev() {
+            let arg = pop(stack)?;
+            new_env.insert(param.clone(), arg);
+        }
+        env_stack.push(std::mem::take(env));
+        ret_stack.push(*pc + 1);
+        *env = new_env;
+        *pc = func.address;
+        *advance_pc = false;
+        Ok(())
+    } else {
+        Err(RuntimeError::UndefinedIdentError(name.to_string()))
+    }
+}
+
+/// Handle the `TAILCALL` instruction.
+pub fn handle_tail_call(
+    name: &str,
+    funcs: &HashMap<String, Function>,
+    stack: &mut Vec<Value>,
+    env: &mut HashMap<String, Value>,
+    pc: &mut usize,
+    advance_pc: &mut bool,
+) -> Result<(), RuntimeError> {
+    if let Some(func) = funcs.get(name) {
+        let mut new_env = HashMap::new();
+        for param in func.params.iter().rev() {
+            let arg = pop(stack)?;
+            new_env.insert(param.clone(), arg);
+        }
+        *env = new_env;
+        *pc = func.address;
+        *advance_pc = false;
+        Ok(())
+    } else {
+        Err(RuntimeError::UndefinedIdentError(name.to_string()))
+    }
+}
+
+/// Handle the `CALLBUILTIN` instruction.
+pub fn handle_call_builtin(
+    name: &str,
+    argc: usize,
+    stack: &mut Vec<Value>,
+    env: &HashMap<String, Value>,
+    globals: &HashMap<String, Value>,
+) -> Result<(), RuntimeError> {
+    let mut args: Vec<Value> = Vec::new();
+    for _ in 0..argc {
+        args.push(pop(stack)?);
+    }
+    args.reverse();
+    match call_builtin(name, &args, env, globals) {
+        Ok(val) => {
+            stack.push(val);
+            Ok(())
+        }
+        Err(e) => Err(e),
+    }
+}
+
+/// Handle the `POP` instruction.
+pub fn handle_pop(stack: &mut Vec<Value>) {
+    stack.pop();
+}
+
+/// Handle the `RET` instruction.
+pub fn handle_ret(
+    stack: &mut Vec<Value>,
+    ret_stack: &mut Vec<usize>,
+    env_stack: &mut Vec<HashMap<String, Value>>,
+    env: &mut HashMap<String, Value>,
+    pc: &mut usize,
+    advance_pc: &mut bool,
+) {
+    let ret_val = stack.pop().unwrap_or(Value::Int(0));
+    *pc = ret_stack.pop().unwrap();
+    *env = env_stack.pop().unwrap();
+    stack.push(ret_val);
+    *advance_pc = false;
+}
+
+/// Handle the `EMIT` instruction.
+pub fn handle_emit(stack: &mut Vec<Value>) {
+    if let Some(v) = stack.pop() {
+        println!("{}", v.to_string());
+    }
+}
+
+/// Handle the `HALT` instruction.
+pub fn handle_halt(pc: &mut usize, code_len: usize, advance_pc: &mut bool) {
+    *pc = code_len;
+    *advance_pc = false;
+}
+
+/// Handle the `SETUPEXCEPT` instruction.
+pub fn handle_setup_except(
+    block_stack: &mut Vec<Block>,
+    handler: usize,
+    stack_size: usize,
+    env_depth: usize,
+    ret_depth: usize,
+) {
+    block_stack.push(Block {
+        handler,
+        stack_size,
+        env_depth,
+        ret_depth,
+    });
+}
+
+/// Handle the `POPBLOCK` instruction.
+pub fn handle_pop_block(block_stack: &mut Vec<Block>) {
+    block_stack.pop();
+}
+
+/// Handle the `RAISE` instruction.
+pub fn handle_raise(stack: &mut Vec<Value>, kind: ErrorKind) -> Result<(), RuntimeError> {
+    let msg_val = stack.pop().ok_or_else(|| {
+        RuntimeError::VmInvariant("stack underflow on RAISE".to_string())
+    })?;
+    let msg = msg_val.to_string();
+    Err(kind.into_runtime(msg))
+}

--- a/runtime/src/vm/ops_struct.rs
+++ b/runtime/src/vm/ops_struct.rs
@@ -1,0 +1,178 @@
+use std::cell::RefCell;
+use std::rc::Rc;
+
+use crate::error::RuntimeError;
+use crate::value::Value;
+
+use super::pop;
+
+/// Handle the `INDEX` instruction.
+pub fn handle_index(stack: &mut Vec<Value>) -> Result<(), RuntimeError> {
+    let idx = pop(stack)?;
+    let base = pop(stack)?;
+    match (base, idx) {
+        (Value::List(list), Value::Int(i)) => {
+            if i < 0 {
+                return Err(RuntimeError::IndexError("List index out of bounds!".to_string()));
+            }
+            let l = list.borrow();
+            let idx_usize = i as usize;
+            if idx_usize < l.len() {
+                stack.push(l[idx_usize].clone());
+            } else {
+                return Err(RuntimeError::IndexError("List index out of bounds!".to_string()));
+            }
+        }
+        (Value::Dict(map), Value::Str(k)) => {
+            if let Some(v) = map.borrow().get(&k).cloned() {
+                stack.push(v);
+            } else {
+                return Err(RuntimeError::KeyError(k));
+            }
+        }
+        (Value::Dict(map), Value::Int(i)) => {
+            let key = i.to_string();
+            if let Some(v) = map.borrow().get(&key).cloned() {
+                stack.push(v);
+            } else {
+                return Err(RuntimeError::KeyError(key));
+            }
+        }
+        (Value::FrozenDict(map), Value::Str(k)) => {
+            if let Some(v) = map.get(&k).cloned() {
+                stack.push(v);
+            } else {
+                return Err(RuntimeError::KeyError(k));
+            }
+        }
+        (Value::FrozenDict(map), Value::Int(i)) => {
+            let key = i.to_string();
+            if let Some(v) = map.get(&key).cloned() {
+                stack.push(v);
+            } else {
+                return Err(RuntimeError::KeyError(key));
+            }
+        }
+        (Value::Str(s), Value::Int(i)) => {
+            if i < 0 {
+                return Err(RuntimeError::IndexError("String index out of bounds!".to_string()));
+            }
+            let chars: Vec<char> = s.chars().collect();
+            let idx_usize = i as usize;
+            if idx_usize < chars.len() {
+                stack.push(Value::Str(chars[idx_usize].to_string()));
+            } else {
+                return Err(RuntimeError::IndexError("String index out of bounds!".to_string()));
+            }
+        }
+        (other, _) => {
+            return Err(RuntimeError::TypeError(format!(
+                "{} is not indexable",
+                other.to_string()
+            )));
+        }
+    }
+    Ok(())
+}
+
+/// Handle the `SLICE` instruction.
+pub fn handle_slice(stack: &mut Vec<Value>) -> Result<(), RuntimeError> {
+    let end_val = pop(stack)?;
+    let start = pop(stack)?.as_int() as usize;
+    let base = pop(stack)?;
+    match base {
+        Value::List(list) => {
+            let list_ref = list.borrow();
+            let end = match end_val {
+                Value::None => list_ref.len(),
+                v => v.as_int() as usize,
+            };
+            let slice = list_ref[start..end].to_vec();
+            stack.push(Value::List(Rc::new(RefCell::new(slice))));
+        }
+        Value::Str(s) => {
+            let chars: Vec<char> = s.chars().collect();
+            let end = match end_val {
+                Value::None => chars.len(),
+                v => v.as_int() as usize,
+            };
+            let slice: String = chars[start..end].iter().collect();
+            stack.push(Value::Str(slice));
+        }
+        _ => stack.push(Value::Int(0)),
+    }
+    Ok(())
+}
+
+/// Handle the `STOREINDEX` instruction.
+pub fn handle_store_index(stack: &mut Vec<Value>) -> Result<(), RuntimeError> {
+    let val = pop(stack)?;
+    let idx = pop(stack)?;
+    let base = pop(stack)?;
+    match (base, idx) {
+        (Value::List(list), Value::Int(i)) => {
+            let mut l = list.borrow_mut();
+            let idx_usize = i as usize;
+            if idx_usize >= l.len() {
+                l.resize(idx_usize + 1, Value::Int(0));
+            }
+            l[idx_usize] = val;
+        }
+        (Value::Dict(map), Value::Str(k)) => {
+            map.borrow_mut().insert(k, val);
+        }
+        (Value::Dict(map), Value::Int(i)) => {
+            map.borrow_mut().insert(i.to_string(), val);
+        }
+        (Value::FrozenDict(_), _) => {
+            return Err(RuntimeError::FrozenWriteError);
+        }
+        _ => {}
+    }
+    Ok(())
+}
+
+/// Handle the `ATTR` instruction.
+pub fn handle_attr(stack: &mut Vec<Value>, attr: &str) -> Result<(), RuntimeError> {
+    let base = pop(stack)?;
+    match base {
+        Value::Dict(map) => {
+            if let Some(v) = map.borrow().get(attr).cloned() {
+                stack.push(v);
+            } else {
+                return Err(RuntimeError::KeyError(attr.to_string()));
+            }
+        }
+        Value::FrozenDict(map) => {
+            if let Some(v) = map.get(attr).cloned() {
+                stack.push(v);
+            } else {
+                return Err(RuntimeError::KeyError(attr.to_string()));
+            }
+        }
+        other => {
+            return Err(RuntimeError::TypeError(format!(
+                "{} has no attribute '{}'",
+                other.to_string(),
+                attr
+            )));
+        }
+    }
+    Ok(())
+}
+
+/// Handle the `STOREATTR` instruction.
+pub fn handle_store_attr(stack: &mut Vec<Value>, attr: &str) -> Result<(), RuntimeError> {
+    let val = pop(stack)?;
+    let base = pop(stack)?;
+    match base {
+        Value::Dict(map) => {
+            map.borrow_mut().insert(attr.to_string(), val);
+        }
+        Value::FrozenDict(_) => {
+            return Err(RuntimeError::FrozenWriteError);
+        }
+        _ => {}
+    }
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- extract arithmetic, structural, and control instruction handlers into dedicated `ops_arith`, `ops_struct`, and `ops_control` modules
- delegate VM `run` loop to new handler functions for clearer dispatch

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68993746094c8323b40ac9ea499cf25e