### PR TITLE
bootstrap: add compiler opcode constants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 Ordered from most recent at the top to oldest at the bottom.
 
+## [0.1.4] - 2025-08-11
+
+### Added
+- Bytecode emission utilities and function tracking structures in the bootstrap compiler.
+
 ## [0.1.3] - 2025-08-11
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 Ordered from most recent at the top to oldest at the bottom.
 
+## [0.1.6] - 2025-08-13
+
+### Added
+- Expression compilation logic in the bootstrap compiler covering literals,
+  variables, function calls, unary and binary operations, indexing, slicing,
+  and attribute access.
+- Special raise-call rewriting via `compile_raise_call` to emit `RAISE`.
+
 ## [0.1.5] - 2025-08-12
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 Ordered from most recent at the top to oldest at the bottom.
 
+## [0.1.7] - 2025-08-18
+
+### Added
+- Final bytecode serialization in the bootstrap compiler, emitting the
+  OMGB header, version, function table, and instruction stream.
+- `compile_source` procedure and CLI wrapper to generate `.omgb` files
+  matching the Python serializer.
+
 ## [0.1.6] - 2025-08-13
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ Ordered from most recent at the top to oldest at the bottom.
 ### Added
 - File I/O builtins `file_open`, `file_read`, `file_write`, `file_close`, and
   `file_exists` with support for text and binary modes.
+- Opcode and error mapping constants for the bootstrap compiler, mirroring the
+  Python implementation.
 
 ## [0.1.2] - 2025-08-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 Ordered from most recent at the top to oldest at the bottom.
 
+## [0.1.9] - 2025-08-18
+
+### Changed
+- Optimized bootstrap compiler to mutate lists in-place, eliminating quadratic concatenation during instruction emission and bytecode serialization.
+
 ## [0.1.8] - 2025-08-18
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 Ordered from most recent at the top to oldest at the bottom.
 
+## [0.1.8] - 2025-08-18
+
+### Added
+- `write_file` builtin for writing text or binary data
+- Exposed error helper builtins for `Syntax`, `Type`, `UndefinedIdent`, `Value`, and `ModuleImport` errors
+
+### Changed
+- Bootstrap compiler CLI uses `write_file` for output
+
 ## [0.1.7] - 2025-08-18
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 Ordered from most recent at the top to oldest at the bottom.
 
+## [0.1.5] - 2025-08-12
+
+### Added
+- Statement compilation logic for declarations, control flow, loops, functions,
+  try/except, and returns in the bootstrap compiler.
+
 ## [0.1.4] - 2025-08-11
 
 ### Added

--- a/bootstrap/compiler.omg
+++ b/bootstrap/compiler.omg
@@ -2,6 +2,17 @@
 
 # Bytecode compiler constants mirrored from Python implementation.
 
+# Import interpreter utilities for tokenizing and parsing without
+# executing its command-line entry point on import.
+alloc _saved_args := args
+args := []
+import "./interpreter.omg" as OMGInterpreter
+args := _saved_args
+
+# Bytecode header and version constants.
+alloc MAGIC_HEADER := [79, 77, 71, 66]
+alloc BC_VERSION := 257  # 0x00000101 (major=0, minor=1, patch=1)
+
 alloc OPCODES := {
     PUSH_INT: 0,
     PUSH_STR: 1,
@@ -52,55 +63,6 @@ alloc OPCODES := {
     RAISE: 46
 }
 
-alloc REV_OPCODES := {
-    0: "PUSH_INT",
-    1: "PUSH_STR",
-    2: "PUSH_BOOL",
-    3: "BUILD_LIST",
-    4: "BUILD_DICT",
-    5: "LOAD",
-    6: "STORE",
-    7: "ADD",
-    8: "SUB",
-    9: "MUL",
-    10: "DIV",
-    11: "MOD",
-    12: "EQ",
-    13: "NE",
-    14: "LT",
-    15: "LE",
-    16: "GT",
-    17: "GE",
-    18: "BAND",
-    19: "BOR",
-    20: "BXOR",
-    21: "SHL",
-    22: "SHR",
-    23: "AND",
-    24: "OR",
-    25: "NOT",
-    26: "NEG",
-    27: "INDEX",
-    28: "SLICE",
-    29: "JUMP",
-    30: "JUMP_IF_FALSE",
-    31: "CALL",
-    32: "TCALL",
-    33: "BUILTIN",
-    34: "POP",
-    35: "PUSH_NONE",
-    36: "RET",
-    37: "EMIT",
-    38: "HALT",
-    39: "STORE_INDEX",
-    40: "ATTR",
-    41: "STORE_ATTR",
-    42: "ASSERT",
-    43: "CALL_VALUE",
-    44: "SETUP_EXCEPT",
-    45: "POP_BLOCK",
-    46: "RAISE"
-}
 
 alloc ERROR_KIND_TO_CODE := {
     Generic: 0,
@@ -111,24 +73,6 @@ alloc ERROR_KIND_TO_CODE := {
     ModuleImport: 5
 }
 
-alloc CODE_TO_ERROR_KIND := {
-    0: "Generic",
-    1: "Syntax",
-    2: "Type",
-    3: "UndefinedIdent",
-    4: "Value",
-    5: "ModuleImport"
-}
-
-alloc ERROR_NAME_TO_KIND := {
-    panic: "Generic",
-    raise: "Generic",
-    _omg_vm_syntax_error_handle: "Syntax",
-    _omg_vm_type_error_handle: "Type",
-    _omg_vm_undef_ident_error_handle: "UndefinedIdent",
-    _omg_vm_value_error_handle: "Value",
-    _omg_vm_module_import_error_handle: "ModuleImport"
-}
 
 # Return opcode value for the given mnemonic.
 proc opcode(name) {
@@ -148,20 +92,105 @@ alloc funcs := []
 alloc break_stack := []
 
 # Names of builtin functions recognized by the compiler.
-alloc BUILTINS := {
-    chr: true,
-    ascii: true,
-    hex: true,
-    binary: true,
-    length: true,
-    read_file: true,
-    freeze: true,
-    call_builtin: true,
-    file_open: true,
-    file_read: true,
-    file_write: true,
-    file_close: true,
-    file_exists: true
+
+# ------------------------------------------------------------------
+# Byte manipulation helpers
+# ------------------------------------------------------------------
+
+# Pack a 32-bit unsigned integer into little-endian byte list.
+proc pack_u32(n) {
+    return [n & 255, (n >> 8) & 255, (n >> 16) & 255, (n >> 24) & 255]
+}
+
+# Pack a 64-bit signed integer into little-endian byte list.
+proc pack_i64(n) {
+    if n < 0 {
+        n := (1 << 64) + n
+    }
+    alloc res := []
+    alloc i := 0
+    loop i < 8 {
+        res := res + [n & 255]
+        n := n >> 8
+        i := i + 1
+    }
+    return res
+}
+
+# Convert a UTF-8 string into a list of byte values.
+proc str_bytes(s) {
+    alloc out := []
+    alloc i := 0
+    alloc n := length(s)
+    loop i < n {
+        out := out + [ascii(s[i])]
+        i := i + 1
+    }
+    return out
+}
+
+# Encode the current bytecode into a list of bytes matching the Python serializer.
+proc encode_bytecode(final_code) {
+    alloc out := MAGIC_HEADER
+    out := out + pack_u32(BC_VERSION)
+    out := out + pack_u32(length(funcs))
+    alloc i := 0
+    loop i < length(funcs) {
+        alloc f := funcs[i]
+        alloc name_bytes := str_bytes(f.name)
+        out := out + pack_u32(length(name_bytes))
+        out := out + name_bytes
+        out := out + pack_u32(length(f.params))
+        alloc j := 0
+        loop j < length(f.params) {
+            alloc pb := str_bytes(f.params[j])
+            out := out + pack_u32(length(pb))
+            out := out + pb
+            j := j + 1
+        }
+        out := out + pack_u32(f.address)
+        i := i + 1
+    }
+    out := out + pack_u32(length(final_code))
+    i := 0
+    loop i < length(final_code) {
+        alloc instr := final_code[i]
+        alloc op := instr[0]
+        alloc arg := instr[1]
+        out := out + [op]
+        if op == opcode("PUSH_INT") {
+            out := out + pack_i64(arg)
+        } elif op == opcode("PUSH_STR") {
+            alloc sb := str_bytes(arg)
+            out := out + pack_u32(length(sb))
+            out := out + sb
+        } elif op == opcode("PUSH_BOOL") {
+            if arg {
+                out := out + [1]
+            } else {
+                out := out + [0]
+            }
+        } elif op == opcode("BUILD_LIST") or op == opcode("BUILD_DICT") or op == opcode("CALL_VALUE") {
+            out := out + pack_u32(arg)
+        } elif op == opcode("LOAD") or op == opcode("STORE") or op == opcode("CALL") or op == opcode("TCALL") or op == opcode("ATTR") or op == opcode("STORE_ATTR") {
+            alloc sb2 := str_bytes(arg)
+            out := out + pack_u32(length(sb2))
+            out := out + sb2
+        } elif op == opcode("BUILTIN") {
+            alloc name := arg[0]
+            alloc argc := arg[1]
+            alloc sb3 := str_bytes(name)
+            out := out + pack_u32(length(sb3))
+            out := out + sb3
+            out := out + pack_u32(argc)
+        } elif op == opcode("RAISE") {
+            out := out + [ERROR_KIND_TO_CODE[arg]]
+        } elif op == opcode("JUMP") or op == opcode("JUMP_IF_FALSE") or op == opcode("SETUP_EXCEPT") {
+            out := out + pack_u32(arg)
+        }
+        i := i + 1
+    }
+    return out
 }
 
 # Create a FunctionEntry record.
@@ -170,7 +199,7 @@ proc make_function_entry(name, params, address) {
 }
 
 # Emit a bytecode instruction.
-proc emit(op, arg) {
+proc emit_instr(op, arg) {
     code := code + [[op, arg]]
 }
 
@@ -185,6 +214,18 @@ proc emit_placeholder(op) {
 proc patch(idx, target) {
     alloc entry := code[idx]
     code[idx] := [entry[0], target]
+}
+
+# Check if a function name corresponds to a built-in.
+proc is_builtin(name) {
+    if name == "chr" or name == "ascii" or name == "hex" or name == "binary" {
+        return true
+    } elif name == "length" or name == "read_file" or name == "freeze" or name == "call_builtin" {
+        return true
+    } elif name == "file_open" or name == "file_read" or name == "file_write" or name == "file_close" or name == "file_exists" {
+        return true
+    }
+    return false
 }
 
 # Compile a block of statements.
@@ -202,19 +243,19 @@ proc compile_stmt(stmt) {
     alloc kind := stmt[0]
     if kind == "emit" {
         compile_expr(stmt[1])
-        emit(opcode("EMIT"), false)
+        emit_instr(opcode("EMIT"), false)
     } elif kind == "decl" or kind == "assign" {
         alloc name := stmt[1]
         alloc expr := stmt[2]
         compile_expr(expr)
-        emit(opcode("STORE"), name)
+        emit_instr(opcode("STORE"), name)
     } elif kind == "attr_assign" {
         alloc base := stmt[1]
         alloc attr := stmt[2]
         alloc expr := stmt[3]
         compile_expr(base)
         compile_expr(expr)
-        emit(opcode("STORE_ATTR"), attr)
+        emit_instr(opcode("STORE_ATTR"), attr)
     } elif kind == "index_assign" {
         alloc base := stmt[1]
         alloc index_expr := stmt[2]
@@ -222,15 +263,15 @@ proc compile_stmt(stmt) {
         compile_expr(base)
         compile_expr(index_expr)
         compile_expr(value_expr)
-        emit(opcode("STORE_INDEX"), false)
+        emit_instr(opcode("STORE_INDEX"), false)
     } elif kind == "expr_stmt" {
         compile_expr(stmt[1])
-        emit(opcode("POP"), false)
+        emit_instr(opcode("POP"), false)
     } elif kind == "import" {
         raise("RuntimeError: Module imports are resolved by the interpreter and cannot be compiled")
     } elif kind == "facts" {
         compile_expr(stmt[1])
-        emit(opcode("ASSERT"), false)
+        emit_instr(opcode("ASSERT"), false)
     } elif kind == "if" {
         alloc cond_blocks := []
         alloc else_block := false
@@ -290,7 +331,7 @@ proc compile_stmt(stmt) {
         alloc jf := emit_placeholder(opcode("JUMP_IF_FALSE"))
         break_stack := break_stack + [[]]
         compile_block(body)
-        emit(opcode("JUMP"), start)
+        emit_instr(opcode("JUMP"), start)
         patch(jf, length(code))
         alloc bs_len := length(break_stack)
         alloc breaks := break_stack[bs_len - 1]
@@ -311,11 +352,11 @@ proc compile_stmt(stmt) {
             try_body := try_block[1]
         }
         compile_block(try_body)
-        emit(opcode("POP_BLOCK"), false)
+        emit_instr(opcode("POP_BLOCK"), false)
         alloc end_jump := emit_placeholder(opcode("JUMP"))
         patch(handler_idx, length(code))
         if exc_name != false {
-            emit(opcode("STORE"), exc_name)
+            emit_instr(opcode("STORE"), exc_name)
         }
         alloc except_body := []
         if except_block[0] == "block" {
@@ -345,15 +386,15 @@ proc compile_stmt(stmt) {
                 compile_expr(args[i])
                 i := i + 1
             }
-            if BUILTINS[name] != false {
-                emit(opcode("BUILTIN"), [name, n])
-                emit(opcode("RET"), false)
+            if is_builtin(name) {
+                emit_instr(opcode("BUILTIN"), [name, n])
+                emit_instr(opcode("RET"), false)
             } else {
-                emit(opcode("TCALL"), name)
+                emit_instr(opcode("TCALL"), name)
             }
         } else {
             compile_expr(expr)
-            emit(opcode("RET"), false)
+            emit_instr(opcode("RET"), false)
         }
     } elif kind == "break" {
         if length(break_stack) == 0 {
@@ -376,24 +417,39 @@ proc _compile_function_body(body) {
     alloc saved_code := code
     code := []
     compile_block(body)
-    emit(opcode("RET"), false)
-    alloc func_code := code
+    emit_instr(opcode("RET"), false)
+    alloc func_code := code + []
     code := saved_code
     return func_code
 }
 
 # Compile special raise helper calls into RAISE instructions.
 proc compile_raise_call(name, args) {
-    alloc kind := ERROR_NAME_TO_KIND[name]
+    alloc kind := false
+    if name == "panic" {
+        kind := "Generic"
+    } elif name == "raise" {
+        kind := "Generic"
+    } elif name == "_omg_vm_syntax_error_handle" {
+        kind := "Syntax"
+    } elif name == "_omg_vm_type_error_handle" {
+        kind := "Type"
+    } elif name == "_omg_vm_undef_ident_error_handle" {
+        kind := "UndefinedIdent"
+    } elif name == "_omg_vm_value_error_handle" {
+        kind := "Value"
+    } elif name == "_omg_vm_module_import_error_handle" {
+        kind := "ModuleImport"
+    }
     if kind == false {
         return false
     }
     if length(args) > 0 {
         compile_expr(args[0])
     } else {
-        emit(opcode("PUSH_STR"), "")
+        emit_instr(opcode("PUSH_STR"), "")
     }
-    emit(opcode("RAISE"), kind)
+    emit_instr(opcode("RAISE"), kind)
     return true
 }
 
@@ -401,13 +457,13 @@ proc compile_raise_call(name, args) {
 proc compile_expr(node) {
     alloc op := node[0]
     if op == "number" {
-        emit(opcode("PUSH_INT"), node[1])
+        emit_instr(opcode("PUSH_INT"), node[1])
     } elif op == "string" {
-        emit(opcode("PUSH_STR"), node[1])
+        emit_instr(opcode("PUSH_STR"), node[1])
     } elif op == "bool" {
-        emit(opcode("PUSH_BOOL"), node[1])
+        emit_instr(opcode("PUSH_BOOL"), node[1])
     } elif op == "ident" {
-        emit(opcode("LOAD"), node[1])
+        emit_instr(opcode("LOAD"), node[1])
     } elif op == "list" {
         alloc elements := node[1]
         alloc i := 0
@@ -416,7 +472,7 @@ proc compile_expr(node) {
             compile_expr(elements[i])
             i := i + 1
         }
-        emit(opcode("BUILD_LIST"), n)
+        emit_instr(opcode("BUILD_LIST"), n)
     } elif op == "dict" {
         alloc pairs := node[1]
         alloc i := 0
@@ -427,24 +483,24 @@ proc compile_expr(node) {
             compile_expr(pair[1])
             i := i + 1
         }
-        emit(opcode("BUILD_DICT"), n)
+        emit_instr(opcode("BUILD_DICT"), n)
     } elif op == "index" {
         compile_expr(node[1])
         compile_expr(node[2])
-        emit(opcode("INDEX"), false)
+        emit_instr(opcode("INDEX"), false)
     } elif op == "slice" {
         compile_expr(node[1])
         compile_expr(node[2])
         alloc end := node[3]
         if end == false {
-            emit(opcode("PUSH_NONE"), false)
+            emit_instr(opcode("PUSH_NONE"), false)
         } else {
             compile_expr(end)
         }
-        emit(opcode("SLICE"), false)
+        emit_instr(opcode("SLICE"), false)
     } elif op == "dot" {
         compile_expr(node[1])
-        emit(opcode("ATTR"), node[2])
+        emit_instr(opcode("ATTR"), node[2])
     } elif op == "func_call" {
         alloc func_node := node[1]
         alloc args := node[2]
@@ -457,10 +513,10 @@ proc compile_expr(node) {
                     compile_expr(args[i])
                     i := i + 1
                 }
-                if BUILTINS[name] != false {
-                    emit(opcode("BUILTIN"), [name, n])
+                if is_builtin(name) {
+                    emit_instr(opcode("BUILTIN"), [name, n])
                 } else {
-                    emit(opcode("CALL"), name)
+                    emit_instr(opcode("CALL"), name)
                 }
             }
         } else {
@@ -471,92 +527,158 @@ proc compile_expr(node) {
                 compile_expr(args[i])
                 i := i + 1
             }
-            emit(opcode("CALL_VALUE"), n)
+            emit_instr(opcode("CALL_VALUE"), n)
         }
     } elif op == "unary" {
         alloc unary_op := node[1]
         compile_expr(node[2])
         if unary_op == "sub" {
-            emit(opcode("NEG"), false)
+            emit_instr(opcode("NEG"), false)
         } elif unary_op == "add" {
             # unary plus does not modify the value
+            alloc noop := 0
         }
     } elif op == "bitnot" {
         compile_expr(node[1])
-        emit(opcode("NOT"), false)
+        emit_instr(opcode("NOT"), false)
     } elif op == "add" {
         compile_expr(node[1])
         compile_expr(node[2])
-        emit(opcode("ADD"), false)
+        emit_instr(opcode("ADD"), false)
     } elif op == "sub" {
         compile_expr(node[1])
         compile_expr(node[2])
-        emit(opcode("SUB"), false)
+        emit_instr(opcode("SUB"), false)
     } elif op == "mul" {
         compile_expr(node[1])
         compile_expr(node[2])
-        emit(opcode("MUL"), false)
+        emit_instr(opcode("MUL"), false)
     } elif op == "div" {
         compile_expr(node[1])
         compile_expr(node[2])
-        emit(opcode("DIV"), false)
+        emit_instr(opcode("DIV"), false)
     } elif op == "mod" {
         compile_expr(node[1])
         compile_expr(node[2])
-        emit(opcode("MOD"), false)
+        emit_instr(opcode("MOD"), false)
     } elif op == "eq" {
         compile_expr(node[1])
         compile_expr(node[2])
-        emit(opcode("EQ"), false)
+        emit_instr(opcode("EQ"), false)
     } elif op == "ne" {
         compile_expr(node[1])
         compile_expr(node[2])
-        emit(opcode("NE"), false)
+        emit_instr(opcode("NE"), false)
     } elif op == "gt" {
         compile_expr(node[1])
         compile_expr(node[2])
-        emit(opcode("GT"), false)
+        emit_instr(opcode("GT"), false)
     } elif op == "lt" {
         compile_expr(node[1])
         compile_expr(node[2])
-        emit(opcode("LT"), false)
+        emit_instr(opcode("LT"), false)
     } elif op == "ge" {
         compile_expr(node[1])
         compile_expr(node[2])
-        emit(opcode("GE"), false)
+        emit_instr(opcode("GE"), false)
     } elif op == "le" {
         compile_expr(node[1])
         compile_expr(node[2])
-        emit(opcode("LE"), false)
+        emit_instr(opcode("LE"), false)
     } elif op == "and" {
         compile_expr(node[1])
         compile_expr(node[2])
-        emit(opcode("AND"), false)
+        emit_instr(opcode("AND"), false)
     } elif op == "or" {
         compile_expr(node[1])
         compile_expr(node[2])
-        emit(opcode("OR"), false)
+        emit_instr(opcode("OR"), false)
     } elif op == "band" {
         compile_expr(node[1])
         compile_expr(node[2])
-        emit(opcode("BAND"), false)
+        emit_instr(opcode("BAND"), false)
     } elif op == "bor" {
         compile_expr(node[1])
         compile_expr(node[2])
-        emit(opcode("BOR"), false)
+        emit_instr(opcode("BOR"), false)
     } elif op == "bxor" {
         compile_expr(node[1])
         compile_expr(node[2])
-        emit(opcode("BXOR"), false)
+        emit_instr(opcode("BXOR"), false)
     } elif op == "shl" {
         compile_expr(node[1])
         compile_expr(node[2])
-        emit(opcode("SHL"), false)
+        emit_instr(opcode("SHL"), false)
     } elif op == "shr" {
         compile_expr(node[1])
         compile_expr(node[2])
-        emit(opcode("SHR"), false)
+        emit_instr(opcode("SHR"), false)
     } else {
         raise("RuntimeError: Unsupported expression node: " + op)
+    }
+}
+
+# ------------------------------------------------------------------
+# Compilation entry points
+# ------------------------------------------------------------------
+
+# Compile an AST into final bytecode.
+proc compile(ast) {
+    code := []
+    pending_funcs := []
+    funcs := []
+    break_stack := []
+    compile_block(ast)
+    emit_instr(opcode("HALT"), false)
+    alloc final_code := code
+    alloc i := 0
+    loop i < length(pending_funcs) {
+        alloc entry := pending_funcs[i]
+        alloc name := entry[0]
+        alloc params := entry[1]
+        alloc body := entry[2]
+        alloc addr := length(final_code)
+        funcs := funcs + [make_function_entry(name, params, addr)]
+        alloc j := 0
+        loop j < length(body) {
+            alloc ins := body[j]
+            alloc op := ins[0]
+            alloc arg := ins[1]
+            if (op == opcode("JUMP") or op == opcode("JUMP_IF_FALSE")) and arg != false {
+                final_code := final_code + [[op, arg + addr]]
+            } else {
+                final_code := final_code + [[op, arg]]
+            }
+            j := j + 1
+        }
+        i := i + 1
+    }
+    return encode_bytecode(final_code)
+}
+
+# Compile source string into bytecode.
+proc compile_source(source, file) {
+    alloc ast := OMGInterpreter.parse(source)
+    return compile(ast)
+}
+
+# ------------------------------------------------------------------
+# CLI entry point
+# ------------------------------------------------------------------
+
+if length(args) > 0 {
+    alloc path := args[0]
+    alloc src := read_file(path)
+    if src == false {
+        raise("RuntimeError: Failed to read file: " + path)
+    }
+    alloc bc := compile_source(src, path)
+    if length(args) > 1 {
+        alloc out_path := args[1]
+        alloc h := file_open(out_path, "wb")
+        file_write(h, bc)
+        file_close(h)
+    } else {
+        emit bc
     }
 }

--- a/bootstrap/compiler.omg
+++ b/bootstrap/compiler.omg
@@ -1,0 +1,136 @@
+;;;omg
+
+# Bytecode compiler constants mirrored from Python implementation.
+
+alloc OPCODES := {
+    PUSH_INT: 0,
+    PUSH_STR: 1,
+    PUSH_BOOL: 2,
+    BUILD_LIST: 3,
+    BUILD_DICT: 4,
+    LOAD: 5,
+    STORE: 6,
+    ADD: 7,
+    SUB: 8,
+    MUL: 9,
+    DIV: 10,
+    MOD: 11,
+    EQ: 12,
+    NE: 13,
+    LT: 14,
+    LE: 15,
+    GT: 16,
+    GE: 17,
+    BAND: 18,
+    BOR: 19,
+    BXOR: 20,
+    SHL: 21,
+    SHR: 22,
+    AND: 23,
+    OR: 24,
+    NOT: 25,
+    NEG: 26,
+    INDEX: 27,
+    SLICE: 28,
+    JUMP: 29,
+    JUMP_IF_FALSE: 30,
+    CALL: 31,
+    TCALL: 32,
+    BUILTIN: 33,
+    POP: 34,
+    PUSH_NONE: 35,
+    RET: 36,
+    EMIT: 37,
+    HALT: 38,
+    STORE_INDEX: 39,
+    ATTR: 40,
+    STORE_ATTR: 41,
+    ASSERT: 42,
+    CALL_VALUE: 43,
+    SETUP_EXCEPT: 44,
+    POP_BLOCK: 45,
+    RAISE: 46
+}
+
+alloc REV_OPCODES := {
+    0: "PUSH_INT",
+    1: "PUSH_STR",
+    2: "PUSH_BOOL",
+    3: "BUILD_LIST",
+    4: "BUILD_DICT",
+    5: "LOAD",
+    6: "STORE",
+    7: "ADD",
+    8: "SUB",
+    9: "MUL",
+    10: "DIV",
+    11: "MOD",
+    12: "EQ",
+    13: "NE",
+    14: "LT",
+    15: "LE",
+    16: "GT",
+    17: "GE",
+    18: "BAND",
+    19: "BOR",
+    20: "BXOR",
+    21: "SHL",
+    22: "SHR",
+    23: "AND",
+    24: "OR",
+    25: "NOT",
+    26: "NEG",
+    27: "INDEX",
+    28: "SLICE",
+    29: "JUMP",
+    30: "JUMP_IF_FALSE",
+    31: "CALL",
+    32: "TCALL",
+    33: "BUILTIN",
+    34: "POP",
+    35: "PUSH_NONE",
+    36: "RET",
+    37: "EMIT",
+    38: "HALT",
+    39: "STORE_INDEX",
+    40: "ATTR",
+    41: "STORE_ATTR",
+    42: "ASSERT",
+    43: "CALL_VALUE",
+    44: "SETUP_EXCEPT",
+    45: "POP_BLOCK",
+    46: "RAISE"
+}
+
+alloc ERROR_KIND_TO_CODE := {
+    Generic: 0,
+    Syntax: 1,
+    Type: 2,
+    UndefinedIdent: 3,
+    Value: 4,
+    ModuleImport: 5
+}
+
+alloc CODE_TO_ERROR_KIND := {
+    0: "Generic",
+    1: "Syntax",
+    2: "Type",
+    3: "UndefinedIdent",
+    4: "Value",
+    5: "ModuleImport"
+}
+
+alloc ERROR_NAME_TO_KIND := {
+    panic: "Generic",
+    raise: "Generic",
+    _omg_vm_syntax_error_handle: "Syntax",
+    _omg_vm_type_error_handle: "Type",
+    _omg_vm_undef_ident_error_handle: "UndefinedIdent",
+    _omg_vm_value_error_handle: "Value",
+    _omg_vm_module_import_error_handle: "ModuleImport"
+}
+
+# Return opcode value for the given mnemonic.
+proc opcode(name) {
+    return OPCODES[name]
+}

--- a/bootstrap/compiler.omg
+++ b/bootstrap/compiler.omg
@@ -381,3 +381,182 @@ proc _compile_function_body(body) {
     code := saved_code
     return func_code
 }
+
+# Compile special raise helper calls into RAISE instructions.
+proc compile_raise_call(name, args) {
+    alloc kind := ERROR_NAME_TO_KIND[name]
+    if kind == false {
+        return false
+    }
+    if length(args) > 0 {
+        compile_expr(args[0])
+    } else {
+        emit(opcode("PUSH_STR"), "")
+    }
+    emit(opcode("RAISE"), kind)
+    return true
+}
+
+# Compile an expression node into bytecode.
+proc compile_expr(node) {
+    alloc op := node[0]
+    if op == "number" {
+        emit(opcode("PUSH_INT"), node[1])
+    } elif op == "string" {
+        emit(opcode("PUSH_STR"), node[1])
+    } elif op == "bool" {
+        emit(opcode("PUSH_BOOL"), node[1])
+    } elif op == "ident" {
+        emit(opcode("LOAD"), node[1])
+    } elif op == "list" {
+        alloc elements := node[1]
+        alloc i := 0
+        alloc n := length(elements)
+        loop i < n {
+            compile_expr(elements[i])
+            i := i + 1
+        }
+        emit(opcode("BUILD_LIST"), n)
+    } elif op == "dict" {
+        alloc pairs := node[1]
+        alloc i := 0
+        alloc n := length(pairs)
+        loop i < n {
+            alloc pair := pairs[i]
+            compile_expr(pair[0])
+            compile_expr(pair[1])
+            i := i + 1
+        }
+        emit(opcode("BUILD_DICT"), n)
+    } elif op == "index" {
+        compile_expr(node[1])
+        compile_expr(node[2])
+        emit(opcode("INDEX"), false)
+    } elif op == "slice" {
+        compile_expr(node[1])
+        compile_expr(node[2])
+        alloc end := node[3]
+        if end == false {
+            emit(opcode("PUSH_NONE"), false)
+        } else {
+            compile_expr(end)
+        }
+        emit(opcode("SLICE"), false)
+    } elif op == "dot" {
+        compile_expr(node[1])
+        emit(opcode("ATTR"), node[2])
+    } elif op == "func_call" {
+        alloc func_node := node[1]
+        alloc args := node[2]
+        if func_node[0] == "ident" {
+            alloc name := func_node[1]
+            if compile_raise_call(name, args) == false {
+                alloc i := 0
+                alloc n := length(args)
+                loop i < n {
+                    compile_expr(args[i])
+                    i := i + 1
+                }
+                if BUILTINS[name] != false {
+                    emit(opcode("BUILTIN"), [name, n])
+                } else {
+                    emit(opcode("CALL"), name)
+                }
+            }
+        } else {
+            compile_expr(func_node)
+            alloc i := 0
+            alloc n := length(args)
+            loop i < n {
+                compile_expr(args[i])
+                i := i + 1
+            }
+            emit(opcode("CALL_VALUE"), n)
+        }
+    } elif op == "unary" {
+        alloc unary_op := node[1]
+        compile_expr(node[2])
+        if unary_op == "sub" {
+            emit(opcode("NEG"), false)
+        } elif unary_op == "add" {
+            # unary plus does not modify the value
+        }
+    } elif op == "bitnot" {
+        compile_expr(node[1])
+        emit(opcode("NOT"), false)
+    } elif op == "add" {
+        compile_expr(node[1])
+        compile_expr(node[2])
+        emit(opcode("ADD"), false)
+    } elif op == "sub" {
+        compile_expr(node[1])
+        compile_expr(node[2])
+        emit(opcode("SUB"), false)
+    } elif op == "mul" {
+        compile_expr(node[1])
+        compile_expr(node[2])
+        emit(opcode("MUL"), false)
+    } elif op == "div" {
+        compile_expr(node[1])
+        compile_expr(node[2])
+        emit(opcode("DIV"), false)
+    } elif op == "mod" {
+        compile_expr(node[1])
+        compile_expr(node[2])
+        emit(opcode("MOD"), false)
+    } elif op == "eq" {
+        compile_expr(node[1])
+        compile_expr(node[2])
+        emit(opcode("EQ"), false)
+    } elif op == "ne" {
+        compile_expr(node[1])
+        compile_expr(node[2])
+        emit(opcode("NE"), false)
+    } elif op == "gt" {
+        compile_expr(node[1])
+        compile_expr(node[2])
+        emit(opcode("GT"), false)
+    } elif op == "lt" {
+        compile_expr(node[1])
+        compile_expr(node[2])
+        emit(opcode("LT"), false)
+    } elif op == "ge" {
+        compile_expr(node[1])
+        compile_expr(node[2])
+        emit(opcode("GE"), false)
+    } elif op == "le" {
+        compile_expr(node[1])
+        compile_expr(node[2])
+        emit(opcode("LE"), false)
+    } elif op == "and" {
+        compile_expr(node[1])
+        compile_expr(node[2])
+        emit(opcode("AND"), false)
+    } elif op == "or" {
+        compile_expr(node[1])
+        compile_expr(node[2])
+        emit(opcode("OR"), false)
+    } elif op == "band" {
+        compile_expr(node[1])
+        compile_expr(node[2])
+        emit(opcode("BAND"), false)
+    } elif op == "bor" {
+        compile_expr(node[1])
+        compile_expr(node[2])
+        emit(opcode("BOR"), false)
+    } elif op == "bxor" {
+        compile_expr(node[1])
+        compile_expr(node[2])
+        emit(opcode("BXOR"), false)
+    } elif op == "shl" {
+        compile_expr(node[1])
+        compile_expr(node[2])
+        emit(opcode("SHL"), false)
+    } elif op == "shr" {
+        compile_expr(node[1])
+        compile_expr(node[2])
+        emit(opcode("SHR"), false)
+    } else {
+        raise("RuntimeError: Unsupported expression node: " + op)
+    }
+}

--- a/bootstrap/compiler.omg
+++ b/bootstrap/compiler.omg
@@ -147,6 +147,23 @@ alloc funcs := []
 # Stack of lists used to patch `break` statements.
 alloc break_stack := []
 
+# Names of builtin functions recognized by the compiler.
+alloc BUILTINS := {
+    chr: true,
+    ascii: true,
+    hex: true,
+    binary: true,
+    length: true,
+    read_file: true,
+    freeze: true,
+    call_builtin: true,
+    file_open: true,
+    file_read: true,
+    file_write: true,
+    file_close: true,
+    file_exists: true
+}
+
 # Create a FunctionEntry record.
 proc make_function_entry(name, params, address) {
     return { name: name, params: params, address: address }
@@ -168,4 +185,199 @@ proc emit_placeholder(op) {
 proc patch(idx, target) {
     alloc entry := code[idx]
     code[idx] := [entry[0], target]
+}
+
+# Compile a block of statements.
+proc compile_block(block) {
+    alloc i := 0
+    alloc n := length(block)
+    loop i < n {
+        compile_stmt(block[i])
+        i := i + 1
+    }
+}
+
+# Compile a single statement node.
+proc compile_stmt(stmt) {
+    alloc kind := stmt[0]
+    if kind == "emit" {
+        compile_expr(stmt[1])
+        emit(opcode("EMIT"), false)
+    } elif kind == "decl" or kind == "assign" {
+        alloc name := stmt[1]
+        alloc expr := stmt[2]
+        compile_expr(expr)
+        emit(opcode("STORE"), name)
+    } elif kind == "attr_assign" {
+        alloc base := stmt[1]
+        alloc attr := stmt[2]
+        alloc expr := stmt[3]
+        compile_expr(base)
+        compile_expr(expr)
+        emit(opcode("STORE_ATTR"), attr)
+    } elif kind == "index_assign" {
+        alloc base := stmt[1]
+        alloc index_expr := stmt[2]
+        alloc value_expr := stmt[3]
+        compile_expr(base)
+        compile_expr(index_expr)
+        compile_expr(value_expr)
+        emit(opcode("STORE_INDEX"), false)
+    } elif kind == "expr_stmt" {
+        compile_expr(stmt[1])
+        emit(opcode("POP"), false)
+    } elif kind == "import" {
+        raise("RuntimeError: Module imports are resolved by the interpreter and cannot be compiled")
+    } elif kind == "facts" {
+        compile_expr(stmt[1])
+        emit(opcode("ASSERT"), false)
+    } elif kind == "if" {
+        alloc cond_blocks := []
+        alloc else_block := false
+        alloc current := stmt
+        loop true {
+            alloc cond := current[1]
+            alloc block_node := current[2]
+            alloc block_stmts := []
+            if block_node[0] == "block" {
+                block_stmts := block_node[1]
+            }
+            cond_blocks := cond_blocks + [[cond, block_stmts]]
+            alloc tail := current[3]
+            if tail != false and tail[0] == "if" {
+                current := tail
+            } else {
+                if tail != false {
+                    if tail[0] == "block" {
+                        else_block := tail[1]
+                    }
+                }
+                break
+            }
+        }
+        alloc end_jumps := []
+        alloc i := 0
+        alloc cb_len := length(cond_blocks)
+        loop i < cb_len {
+            alloc pair := cond_blocks[i]
+            alloc cond := pair[0]
+            alloc block := pair[1]
+            compile_expr(cond)
+            alloc jf := emit_placeholder(opcode("JUMP_IF_FALSE"))
+            compile_block(block)
+            end_jumps := end_jumps + [emit_placeholder(opcode("JUMP"))]
+            patch(jf, length(code))
+            i := i + 1
+        }
+        if else_block != false {
+            compile_block(else_block)
+        }
+        alloc j := 0
+        alloc ej_len := length(end_jumps)
+        loop j < ej_len {
+            patch(end_jumps[j], length(code))
+            j := j + 1
+        }
+    } elif kind == "loop" {
+        alloc cond := stmt[1]
+        alloc body_node := stmt[2]
+        alloc body := []
+        if body_node[0] == "block" {
+            body := body_node[1]
+        }
+        alloc start := length(code)
+        compile_expr(cond)
+        alloc jf := emit_placeholder(opcode("JUMP_IF_FALSE"))
+        break_stack := break_stack + [[]]
+        compile_block(body)
+        emit(opcode("JUMP"), start)
+        patch(jf, length(code))
+        alloc bs_len := length(break_stack)
+        alloc breaks := break_stack[bs_len - 1]
+        break_stack := break_stack[0:bs_len - 1]
+        alloc k := 0
+        alloc b_len := length(breaks)
+        loop k < b_len {
+            patch(breaks[k], length(code))
+            k := k + 1
+        }
+    } elif kind == "try" {
+        alloc try_block := stmt[1]
+        alloc exc_name := stmt[2]
+        alloc except_block := stmt[3]
+        alloc handler_idx := emit_placeholder(opcode("SETUP_EXCEPT"))
+        alloc try_body := []
+        if try_block[0] == "block" {
+            try_body := try_block[1]
+        }
+        compile_block(try_body)
+        emit(opcode("POP_BLOCK"), false)
+        alloc end_jump := emit_placeholder(opcode("JUMP"))
+        patch(handler_idx, length(code))
+        if exc_name != false {
+            emit(opcode("STORE"), exc_name)
+        }
+        alloc except_body := []
+        if except_block[0] == "block" {
+            except_body := except_block[1]
+        }
+        compile_block(except_body)
+        patch(end_jump, length(code))
+    } elif kind == "func_def" {
+        alloc name := stmt[1]
+        alloc params := stmt[2]
+        alloc body_node := stmt[3]
+        alloc body := []
+        if body_node[0] == "block" {
+            body := body_node[1]
+        }
+        alloc body_code := _compile_function_body(body)
+        pending_funcs := pending_funcs + [[name, params, body_code]]
+    } elif kind == "return" {
+        alloc expr := stmt[1]
+        if expr[0] == "func_call" and expr[1][0] == "ident" {
+            alloc func_node := expr[1]
+            alloc args := expr[2]
+            alloc name := func_node[1]
+            alloc i := 0
+            alloc n := length(args)
+            loop i < n {
+                compile_expr(args[i])
+                i := i + 1
+            }
+            if BUILTINS[name] != false {
+                emit(opcode("BUILTIN"), [name, n])
+                emit(opcode("RET"), false)
+            } else {
+                emit(opcode("TCALL"), name)
+            }
+        } else {
+            compile_expr(expr)
+            emit(opcode("RET"), false)
+        }
+    } elif kind == "break" {
+        if length(break_stack) == 0 {
+            raise("SyntaxError: 'break' used outside of loop")
+        }
+        alloc j := emit_placeholder(opcode("JUMP"))
+        alloc bs_len := length(break_stack)
+        alloc top := break_stack[bs_len - 1]
+        top := top + [j]
+        break_stack[bs_len - 1] := top
+    } elif kind == "block" {
+        compile_block(stmt[1])
+    } else {
+        raise("RuntimeError: Unsupported statement: " + kind)
+    }
+}
+
+# Compile the body of a function into bytecode.
+proc _compile_function_body(body) {
+    alloc saved_code := code
+    code := []
+    compile_block(body)
+    emit(opcode("RET"), false)
+    alloc func_code := code
+    code := saved_code
+    return func_code
 }

--- a/bootstrap/compiler.omg
+++ b/bootstrap/compiler.omg
@@ -220,7 +220,7 @@ proc patch(idx, target) {
 proc is_builtin(name) {
     if name == "chr" or name == "ascii" or name == "hex" or name == "binary" {
         return true
-    } elif name == "length" or name == "read_file" or name == "freeze" or name == "call_builtin" {
+    } elif name == "length" or name == "read_file" or name == "write_file" or name == "freeze" or name == "call_builtin" {
         return true
     } elif name == "file_open" or name == "file_read" or name == "file_write" or name == "file_close" or name == "file_exists" {
         return true
@@ -675,9 +675,7 @@ if length(args) > 0 {
     alloc bc := compile_source(src, path)
     if length(args) > 1 {
         alloc out_path := args[1]
-        alloc h := file_open(out_path, "wb")
-        file_write(h, bc)
-        file_close(h)
+        write_file(out_path, bc)
     } else {
         emit bc
     }

--- a/bootstrap/compiler.omg
+++ b/bootstrap/compiler.omg
@@ -80,16 +80,20 @@ proc opcode(name) {
 }
 
 # Current instruction stream as a list of [op, arg] pairs.
-alloc code := []
+alloc code := {}
+alloc code_len := 0
 
 # Pending function bodies waiting to be appended.
-alloc pending_funcs := []
+alloc pending_funcs := {}
+alloc pending_funcs_len := 0
 
 # Finalized function metadata entries.
-alloc funcs := []
+alloc funcs := {}
+alloc funcs_len := 0
 
 # Stack of lists used to patch `break` statements.
-alloc break_stack := []
+alloc break_stack := {}
+alloc break_stack_len := 0
 
 # Names of builtin functions recognized by the compiler.
 
@@ -129,68 +133,105 @@ proc str_bytes(s) {
     return out
 }
 
-# Encode the current bytecode into a list of bytes matching the Python serializer.
-proc encode_bytecode(final_code) {
-    alloc out := MAGIC_HEADER
-    out := out + pack_u32(BC_VERSION)
-    out := out + pack_u32(length(funcs))
+# Append a list of bytes to the destination buffer.
+proc append_bytes(buf, len, bytes) {
     alloc i := 0
-    loop i < length(funcs) {
+    alloc n := length(bytes)
+    loop i < n {
+        buf[len] := bytes[i]
+        len := len + 1
+        i := i + 1
+    }
+    return len
+}
+
+# Create a list of zero bytes with the given size using doubling to avoid quadratic behavior.
+proc make_list(n) {
+    if n == 0 {
+        return []
+    }
+    alloc res := [0]
+    alloc size := 1
+    loop size < n {
+        res := res + res
+        size := size * 2
+    }
+    return res[0:n]
+}
+
+# Encode the current bytecode into a list of bytes matching the Python serializer.
+proc encode_bytecode(final_code, final_code_len) {
+    alloc out := {}
+    alloc out_len := 0
+    out_len := append_bytes(out, out_len, MAGIC_HEADER)
+    out_len := append_bytes(out, out_len, pack_u32(BC_VERSION))
+    out_len := append_bytes(out, out_len, pack_u32(funcs_len))
+    alloc i := 0
+    loop i < funcs_len {
         alloc f := funcs[i]
         alloc name_bytes := str_bytes(f.name)
-        out := out + pack_u32(length(name_bytes))
-        out := out + name_bytes
-        out := out + pack_u32(length(f.params))
+        out_len := append_bytes(out, out_len, pack_u32(length(name_bytes)))
+        out_len := append_bytes(out, out_len, name_bytes)
+        out_len := append_bytes(out, out_len, pack_u32(length(f.params)))
         alloc j := 0
         loop j < length(f.params) {
             alloc pb := str_bytes(f.params[j])
-            out := out + pack_u32(length(pb))
-            out := out + pb
+            out_len := append_bytes(out, out_len, pack_u32(length(pb)))
+            out_len := append_bytes(out, out_len, pb)
             j := j + 1
         }
-        out := out + pack_u32(f.address)
+        out_len := append_bytes(out, out_len, pack_u32(f.address))
         i := i + 1
     }
-    out := out + pack_u32(length(final_code))
+    out_len := append_bytes(out, out_len, pack_u32(final_code_len))
     i := 0
-    loop i < length(final_code) {
+    loop i < final_code_len {
         alloc instr := final_code[i]
         alloc op := instr[0]
         alloc arg := instr[1]
-        out := out + [op]
+        out[out_len] := op
+        out_len := out_len + 1
         if op == opcode("PUSH_INT") {
-            out := out + pack_i64(arg)
+            out_len := append_bytes(out, out_len, pack_i64(arg))
         } elif op == opcode("PUSH_STR") {
             alloc sb := str_bytes(arg)
-            out := out + pack_u32(length(sb))
-            out := out + sb
+            out_len := append_bytes(out, out_len, pack_u32(length(sb)))
+            out_len := append_bytes(out, out_len, sb)
         } elif op == opcode("PUSH_BOOL") {
             if arg {
-                out := out + [1]
+                out[out_len] := 1
             } else {
-                out := out + [0]
+                out[out_len] := 0
             }
+            out_len := out_len + 1
         } elif op == opcode("BUILD_LIST") or op == opcode("BUILD_DICT") or op == opcode("CALL_VALUE") {
-            out := out + pack_u32(arg)
+            out_len := append_bytes(out, out_len, pack_u32(arg))
         } elif op == opcode("LOAD") or op == opcode("STORE") or op == opcode("CALL") or op == opcode("TCALL") or op == opcode("ATTR") or op == opcode("STORE_ATTR") {
             alloc sb2 := str_bytes(arg)
-            out := out + pack_u32(length(sb2))
-            out := out + sb2
+            out_len := append_bytes(out, out_len, pack_u32(length(sb2)))
+            out_len := append_bytes(out, out_len, sb2)
         } elif op == opcode("BUILTIN") {
             alloc name := arg[0]
             alloc argc := arg[1]
             alloc sb3 := str_bytes(name)
-            out := out + pack_u32(length(sb3))
-            out := out + sb3
-            out := out + pack_u32(argc)
+            out_len := append_bytes(out, out_len, pack_u32(length(sb3)))
+            out_len := append_bytes(out, out_len, sb3)
+            out_len := append_bytes(out, out_len, pack_u32(argc))
         } elif op == opcode("RAISE") {
-            out := out + [ERROR_KIND_TO_CODE[arg]]
+            out[out_len] := ERROR_KIND_TO_CODE[arg]
+            out_len := out_len + 1
         } elif op == opcode("JUMP") or op == opcode("JUMP_IF_FALSE") or op == opcode("SETUP_EXCEPT") {
-            out := out + pack_u32(arg)
+            out_len := append_bytes(out, out_len, pack_u32(arg))
         }
         i := i + 1
     }
-    return out
+    alloc res := make_list(out_len)
+    i := 0
+    loop i < out_len {
+        res[i] := out[i]
+        i := i + 1
+    }
+    return res
 }
 
 # Create a FunctionEntry record.
@@ -200,13 +241,15 @@ proc make_function_entry(name, params, address) {
 
 # Emit a bytecode instruction.
 proc emit_instr(op, arg) {
-    code := code + [[op, arg]]
+    code[code_len] := [op, arg]
+    code_len := code_len + 1
 }
 
 # Emit a placeholder instruction and return its index for later patching.
 proc emit_placeholder(op) {
-    alloc idx := length(code)
-    code := code + [[op, false]]
+    alloc idx := code_len
+    code[code_len] := [op, false]
+    code_len := code_len + 1
     return idx
 }
 
@@ -307,7 +350,7 @@ proc compile_stmt(stmt) {
             alloc jf := emit_placeholder(opcode("JUMP_IF_FALSE"))
             compile_block(block)
             end_jumps := end_jumps + [emit_placeholder(opcode("JUMP"))]
-            patch(jf, length(code))
+            patch(jf, code_len)
             i := i + 1
         }
         if else_block != false {
@@ -316,7 +359,7 @@ proc compile_stmt(stmt) {
         alloc j := 0
         alloc ej_len := length(end_jumps)
         loop j < ej_len {
-            patch(end_jumps[j], length(code))
+            patch(end_jumps[j], code_len)
             j := j + 1
         }
     } elif kind == "loop" {
@@ -326,20 +369,21 @@ proc compile_stmt(stmt) {
         if body_node[0] == "block" {
             body := body_node[1]
         }
-        alloc start := length(code)
+        alloc start := code_len
         compile_expr(cond)
         alloc jf := emit_placeholder(opcode("JUMP_IF_FALSE"))
-        break_stack := break_stack + [[]]
+        break_stack[break_stack_len] := []
+        break_stack_len := break_stack_len + 1
         compile_block(body)
         emit_instr(opcode("JUMP"), start)
-        patch(jf, length(code))
-        alloc bs_len := length(break_stack)
+        patch(jf, code_len)
+        alloc bs_len := break_stack_len
         alloc breaks := break_stack[bs_len - 1]
-        break_stack := break_stack[0:bs_len - 1]
+        break_stack_len := bs_len - 1
         alloc k := 0
         alloc b_len := length(breaks)
         loop k < b_len {
-            patch(breaks[k], length(code))
+            patch(breaks[k], code_len)
             k := k + 1
         }
     } elif kind == "try" {
@@ -354,7 +398,7 @@ proc compile_stmt(stmt) {
         compile_block(try_body)
         emit_instr(opcode("POP_BLOCK"), false)
         alloc end_jump := emit_placeholder(opcode("JUMP"))
-        patch(handler_idx, length(code))
+        patch(handler_idx, code_len)
         if exc_name != false {
             emit_instr(opcode("STORE"), exc_name)
         }
@@ -363,7 +407,7 @@ proc compile_stmt(stmt) {
             except_body := except_block[1]
         }
         compile_block(except_body)
-        patch(end_jump, length(code))
+        patch(end_jump, code_len)
     } elif kind == "func_def" {
         alloc name := stmt[1]
         alloc params := stmt[2]
@@ -373,7 +417,8 @@ proc compile_stmt(stmt) {
             body := body_node[1]
         }
         alloc body_code := _compile_function_body(body)
-        pending_funcs := pending_funcs + [[name, params, body_code]]
+        pending_funcs[pending_funcs_len] := [name, params, body_code]
+        pending_funcs_len := pending_funcs_len + 1
     } elif kind == "return" {
         alloc expr := stmt[1]
         if expr[0] == "func_call" and expr[1][0] == "ident" {
@@ -397,11 +442,11 @@ proc compile_stmt(stmt) {
             emit_instr(opcode("RET"), false)
         }
     } elif kind == "break" {
-        if length(break_stack) == 0 {
+        if break_stack_len == 0 {
             raise("SyntaxError: 'break' used outside of loop")
         }
         alloc j := emit_placeholder(opcode("JUMP"))
-        alloc bs_len := length(break_stack)
+        alloc bs_len := break_stack_len
         alloc top := break_stack[bs_len - 1]
         top := top + [j]
         break_stack[bs_len - 1] := top
@@ -415,11 +460,25 @@ proc compile_stmt(stmt) {
 # Compile the body of a function into bytecode.
 proc _compile_function_body(body) {
     alloc saved_code := code
-    code := []
+    alloc saved_len := code_len
+    alloc saved_stack := break_stack
+    alloc saved_stack_len := break_stack_len
+    code := {}
+    code_len := 0
+    break_stack := {}
+    break_stack_len := 0
     compile_block(body)
     emit_instr(opcode("RET"), false)
-    alloc func_code := code + []
+    alloc func_code := make_list(code_len)
+    alloc i := 0
+    loop i < code_len {
+        func_code[i] := code[i]
+        i := i + 1
+    }
     code := saved_code
+    code_len := saved_len
+    break_stack := saved_stack
+    break_stack_len := saved_stack_len
     return func_code
 }
 
@@ -624,36 +683,43 @@ proc compile_expr(node) {
 
 # Compile an AST into final bytecode.
 proc compile(ast) {
-    code := []
-    pending_funcs := []
-    funcs := []
-    break_stack := []
+    code := {}
+    code_len := 0
+    pending_funcs := {}
+    pending_funcs_len := 0
+    funcs := {}
+    funcs_len := 0
+    break_stack := {}
+    break_stack_len := 0
     compile_block(ast)
     emit_instr(opcode("HALT"), false)
     alloc final_code := code
+    alloc final_code_len := code_len
     alloc i := 0
-    loop i < length(pending_funcs) {
+    loop i < pending_funcs_len {
         alloc entry := pending_funcs[i]
         alloc name := entry[0]
         alloc params := entry[1]
         alloc body := entry[2]
-        alloc addr := length(final_code)
-        funcs := funcs + [make_function_entry(name, params, addr)]
+        alloc addr := final_code_len
+        funcs[funcs_len] := make_function_entry(name, params, addr)
+        funcs_len := funcs_len + 1
         alloc j := 0
         loop j < length(body) {
             alloc ins := body[j]
             alloc op := ins[0]
             alloc arg := ins[1]
             if (op == opcode("JUMP") or op == opcode("JUMP_IF_FALSE")) and arg != false {
-                final_code := final_code + [[op, arg + addr]]
+                final_code[final_code_len] := [op, arg + addr]
             } else {
-                final_code := final_code + [[op, arg]]
+                final_code[final_code_len] := [op, arg]
             }
+            final_code_len := final_code_len + 1
             j := j + 1
         }
         i := i + 1
     }
-    return encode_bytecode(final_code)
+    return encode_bytecode(final_code, final_code_len)
 }
 
 # Compile source string into bytecode.

--- a/bootstrap/compiler.omg
+++ b/bootstrap/compiler.omg
@@ -134,3 +134,38 @@ alloc ERROR_NAME_TO_KIND := {
 proc opcode(name) {
     return OPCODES[name]
 }
+
+# Current instruction stream as a list of [op, arg] pairs.
+alloc code := []
+
+# Pending function bodies waiting to be appended.
+alloc pending_funcs := []
+
+# Finalized function metadata entries.
+alloc funcs := []
+
+# Stack of lists used to patch `break` statements.
+alloc break_stack := []
+
+# Create a FunctionEntry record.
+proc make_function_entry(name, params, address) {
+    return { name: name, params: params, address: address }
+}
+
+# Emit a bytecode instruction.
+proc emit(op, arg) {
+    code := code + [[op, arg]]
+}
+
+# Emit a placeholder instruction and return its index for later patching.
+proc emit_placeholder(op) {
+    alloc idx := length(code)
+    code := code + [[op, false]]
+    return idx
+}
+
+# Patch a previously emitted placeholder with the given target.
+proc patch(idx, target) {
+    alloc entry := code[idx]
+    code[idx] := [entry[0], target]
+}

--- a/bootstrap/interpreter.omg
+++ b/bootstrap/interpreter.omg
@@ -860,6 +860,7 @@ proc import_module(path) {
     alloc env := [
         ["length", ["builtin", "length"]],
         ["read_file", ["builtin", "read_file"]],
+        ["write_file", ["builtin", "write_file"]],
         ["ascii", ["builtin", "ascii"]],
         ["binary", ["builtin", "binary"]],
         ["chr", ["builtin", "chr"]],
@@ -870,7 +871,12 @@ proc import_module(path) {
         ["file_write", ["builtin", "file_write"]],
         ["file_close", ["builtin", "file_close"]],
         ["file_exists", ["builtin", "file_exists"]],
-        ["raise", ["builtin", "raise"]]
+        ["raise", ["builtin", "raise"]],
+        ["_omg_vm_syntax_error_handle", ["builtin", "_omg_vm_syntax_error_handle"]],
+        ["_omg_vm_type_error_handle", ["builtin", "_omg_vm_type_error_handle"]],
+        ["_omg_vm_undef_ident_error_handle", ["builtin", "_omg_vm_undef_ident_error_handle"]],
+        ["_omg_vm_value_error_handle", ["builtin", "_omg_vm_value_error_handle"]],
+        ["_omg_vm_module_import_error_handle", ["builtin", "_omg_vm_module_import_error_handle"]]
     ]
     env := env_set(env, "args", [])
     global_env := env
@@ -1173,6 +1179,7 @@ proc run(source) {
     alloc env := [
         ["length", ["builtin", "length"]],
         ["read_file", ["builtin", "read_file"]],
+        ["write_file", ["builtin", "write_file"]],
         ["ascii", ["builtin", "ascii"]],
         ["binary", ["builtin", "binary"]],
         ["chr", ["builtin", "chr"]],
@@ -1183,7 +1190,12 @@ proc run(source) {
         ["file_write", ["builtin", "file_write"]],
         ["file_close", ["builtin", "file_close"]],
         ["file_exists", ["builtin", "file_exists"]],
-        ["raise", ["builtin", "raise"]]
+        ["raise", ["builtin", "raise"]],
+        ["_omg_vm_syntax_error_handle", ["builtin", "_omg_vm_syntax_error_handle"]],
+        ["_omg_vm_type_error_handle", ["builtin", "_omg_vm_type_error_handle"]],
+        ["_omg_vm_undef_ident_error_handle", ["builtin", "_omg_vm_undef_ident_error_handle"]],
+        ["_omg_vm_value_error_handle", ["builtin", "_omg_vm_value_error_handle"]],
+        ["_omg_vm_module_import_error_handle", ["builtin", "_omg_vm_module_import_error_handle"]]
     ]
     env := env_set(env, "args", args)
     global_env := env

--- a/omglang/interpreter.py
+++ b/omglang/interpreter.py
@@ -100,13 +100,12 @@ class Interpreter:
             RuntimeError: If the header is missing or incorrect.
         """
         for line in source_code.splitlines():
-            if line.strip() == '':
+            if line.strip() == "":
                 continue
-            if line.strip() == ';;;omg':
+            if line.strip() == ";;;omg":
                 return
         raise RuntimeError(
-            f"OMG script missing required header ';;;omg' "
-            f"in {self.file}"
+            f"OMG script missing required header ';;;omg' " f"in {self.file}"
         )
 
     def strip_header(self, source_code: str) -> str:
@@ -118,11 +117,10 @@ class Interpreter:
         """
         lines = source_code.splitlines()
         for i, line in enumerate(lines):
-            if line.strip() == ';;;omg':
-                return '\n'.join(lines[i + 1:])
+            if line.strip() == ";;;omg":
+                return "\n".join(lines[i + 1 :])
         raise RuntimeError(
-            f"OMG script missing required header ';;;omg'\n"
-            f"in {self.file}"
+            f"OMG script missing required header ';;;omg'\n" f"in {self.file}"
         )
 
     def _resolve_path(self, path: str) -> Path:
@@ -155,13 +153,19 @@ class Interpreter:
         Returns:
             FrozenNamespace: A read-only namespace containing the module's exported variables.
         """
-        base_dir = os.path.dirname(self.file) if self.file not in {"<stdin>", "<test>"} else os.getcwd()
+        base_dir = (
+            os.path.dirname(self.file)
+            if self.file not in {"<stdin>", "<test>"}
+            else os.getcwd()
+        )
         module_path = os.path.normpath(os.path.abspath(os.path.join(base_dir, path)))
 
         if module_path in self.loaded_modules:
             raise RuntimeError(f"Recursive import of '{module_path}'")
         if not os.path.exists(module_path):
-            raise FileNotFoundError(f"Module '{path}' not found relative to '{self.file}'")
+            raise FileNotFoundError(
+                f"Module '{path}' not found relative to '{self.file}'"
+            )
 
         self.loaded_modules.add(module_path)
         try:
@@ -188,7 +192,9 @@ class Interpreter:
 
             module_interpreter.execute(ast)
 
-            exported_bindings = {name: module_interpreter.vars.get(name) for name in exports}
+            exported_bindings = {
+                name: module_interpreter.vars.get(name) for name in exports
+            }
             return FrozenNamespace(exported_bindings)
         except SyntaxError as e:
             raise SyntaxError(f"Error in module '{module_path}': {e}") from e
@@ -212,25 +218,29 @@ class Interpreter:
                     f"({self._format_expr(node[1])} == "
                     f"{self._format_expr(node[2])})"
                 )
-            case 'ident':
+            case "ident":
                 return node[1]
-            case 'number' | 'bool' | 'int':
+            case "number" | "bool" | "int":
                 return str(node[1])
-            case 'string':
+            case "string":
                 return repr(node[1])
-            case 'list':
-                return '[' + ', '.join(self._format_expr(e) for e in node[1]) + ']'
-            case 'dict':
-                return '{' + ', '.join(f"{k}: {self._format_expr(v)}" for k, v in node[1]) + '}'
-            case 'index':
+            case "list":
+                return "[" + ", ".join(self._format_expr(e) for e in node[1]) + "]"
+            case "dict":
+                return (
+                    "{"
+                    + ", ".join(f"{k}: {self._format_expr(v)}" for k, v in node[1])
+                    + "}"
+                )
+            case "index":
                 return f"{self._format_expr(node[1])}[{self._format_expr(node[2])}]"
-            case 'slice':
+            case "slice":
                 start = self._format_expr(node[2])
-                end = '' if node[3] is None else self._format_expr(node[3])
+                end = "" if node[3] is None else self._format_expr(node[3])
                 return f"{self._format_expr(node[1])}[{start}:{end}]"
-            case 'dot':
+            case "dot":
                 return f"{self._format_expr(node[1])}.{node[2]}"
-            case 'func_call':
+            case "func_call":
                 func_expr, args, _ = node[1], node[2], node[3]
                 return (
                     f"{self._format_expr(func_expr)}"
@@ -262,21 +272,21 @@ class Interpreter:
             line = node[-1]
 
             # Literals
-            if op == 'number':
+            if op == "number":
                 return node[1]
-            elif op == 'string':
+            elif op == "string":
                 return node[1]
-            elif op == 'bool':
+            elif op == "bool":
                 return node[1]
-            elif op == 'list':
+            elif op == "list":
                 _, elements, _ = node
                 return [self.eval_expr(elem) for elem in elements]
-            elif op == 'dict':
+            elif op == "dict":
                 _, pairs, _ = node
                 return {k: self.eval_expr(v) for k, v in pairs}
 
             # Variables
-            elif op == 'ident':
+            elif op == "ident":
                 varname = node[1]
                 if varname in self.vars:
                     return self.vars[varname]
@@ -285,7 +295,7 @@ class Interpreter:
                 raise UndefinedVariableException(varname, line, self.file)
 
             # Indexes
-            elif op == 'index':
+            elif op == "index":
                 _, target_node, index_expr, _ = node
                 target = self.eval_expr(target_node)
                 index = self.eval_expr(index_expr)
@@ -318,7 +328,7 @@ class Interpreter:
                 )
 
             # Index slicing
-            elif op == 'slice':
+            elif op == "slice":
                 _, target_node, start_expr, end_expr, _ = node
                 target = self.eval_expr(target_node)
                 start = self.eval_expr(start_expr)
@@ -330,7 +340,7 @@ class Interpreter:
                     f"{self._format_expr(node)}\n"
                     f"On line {line} in {self.file}"
                 )
-            elif op == 'dot':
+            elif op == "dot":
                 _, target_node, attr_name, _ = node
                 target = self.eval_expr(target_node)
                 if not isinstance(target, dict):
@@ -417,13 +427,11 @@ class Interpreter:
                     case Op.LE:
                         term = lhs <= rhs
                     case _:
-                        raise UnknownOpException(
-                            f"Unknown binary operator '{op}'"
-                        )
+                        raise UnknownOpException(f"Unknown binary operator '{op}'")
                 return term
 
             # Unary operator
-            elif op == 'unary':
+            elif op == "unary":
                 operator = node[1]
                 operand = self.eval_expr(node[2])
                 match operator:
@@ -459,14 +467,14 @@ class Interpreter:
                         )
 
             # Function calls
-            elif op == 'func_call':
+            elif op == "func_call":
                 _, func_node, args_nodes, line = node
                 args = [self.eval_expr(arg) for arg in args_nodes]
 
                 # Handle built-in functions before resolving variables
-                if func_node[0] == 'ident':
+                if func_node[0] == "ident":
                     func_name = func_node[1]
-                    if func_name == 'chr':
+                    if func_name == "chr":
                         if len(args) != 1 or not isinstance(args[0], int):
                             raise TypeError(
                                 f"chr() expects one integer argument!\n"
@@ -474,15 +482,19 @@ class Interpreter:
                             )
                         return chr(args[0])
 
-                    if func_name == 'ascii':
-                        if len(args) != 1 or not isinstance(args[0], str) or len(args[0]) != 1:
+                    if func_name == "ascii":
+                        if (
+                            len(args) != 1
+                            or not isinstance(args[0], str)
+                            or len(args[0]) != 1
+                        ):
                             raise TypeError(
                                 f"ascii() expects a single-character string argument!\n"
                                 f"on line {line} in {self.file}"
                             )
                         return ord(args[0])
 
-                    if func_name == 'hex':
+                    if func_name == "hex":
                         if len(args) != 1 or not isinstance(args[0], int):
                             raise TypeError(
                                 f"hex() expects one integer argument!\n"
@@ -490,7 +502,7 @@ class Interpreter:
                             )
                         return str(hex(args[0])[2:]).upper()
 
-                    if func_name == 'binary':
+                    if func_name == "binary":
                         if (
                             len(args) not in (1, 2)
                             or not isinstance(args[0], int)
@@ -502,7 +514,7 @@ class Interpreter:
                             )
                         n = args[0]
                         if len(args) == 1:
-                            return ('-' + bin(abs(n))[2:]) if n < 0 else bin(n)[2:]
+                            return ("-" + bin(abs(n))[2:]) if n < 0 else bin(n)[2:]
                         width = args[1]
                         if width <= 0:
                             raise ValueError(
@@ -510,9 +522,9 @@ class Interpreter:
                                 f"on line {line} in {self.file}"
                             )
                         mask = (1 << width) - 1
-                        return format(n & mask, f'0{width}b')
+                        return format(n & mask, f"0{width}b")
 
-                    if func_name == 'length':
+                    if func_name == "length":
                         if len(args) != 1:
                             raise TypeError(
                                 f"length() expects one argument on line!\n"
@@ -526,7 +538,7 @@ class Interpreter:
                             )
                         return len(arg)
 
-                    if func_name == 'read_file':
+                    if func_name == "read_file":
                         if len(args) != 1 or not isinstance(args[0], str):
                             raise TypeError(
                                 f"read_file() expects a file path string!\n"
@@ -539,7 +551,33 @@ class Interpreter:
                         except OSError:
                             return False
 
-                    if func_name == 'file_open':
+                    if func_name == "write_file":
+                        if len(args) != 2 or not isinstance(args[0], str):
+                            raise TypeError(
+                                f"write_file() expects path and data!\n"
+                                f"on line {line} in {self.file}"
+                            )
+                        path = self._resolve_path(args[0])
+                        data = args[1]
+                        try:
+                            if isinstance(data, str):
+                                path.write_text(data, encoding="utf-8")
+                                return len(data.encode("utf-8"))
+                            if isinstance(data, list) and all(
+                                isinstance(b, int) and 0 <= b <= 255 for b in data
+                            ):
+                                path.write_bytes(bytes(data))
+                                return len(data)
+                            raise TypeError(
+                                f"write_file() expects string or list of bytes!\n"
+                                f"on line {line} in {self.file}"
+                            )
+                        except OSError as e:
+                            raise RuntimeError(
+                                f"Cannot write file '{path}': {e}"
+                            ) from e
+
+                    if func_name == "file_open":
                         if (
                             len(args) != 2
                             or not isinstance(args[0], str)
@@ -552,20 +590,18 @@ class Interpreter:
                         path = self._resolve_path(args[0])
                         mode = args[1]
                         try:
-                            if 'b' in mode:
+                            if "b" in mode:
                                 fobj = open(path, mode)
                             else:
                                 fobj = open(path, mode, encoding="utf-8")
                         except OSError as e:
-                            raise RuntimeError(
-                                f"Cannot open file '{path}': {e}"
-                            ) from e
+                            raise RuntimeError(f"Cannot open file '{path}': {e}") from e
                         handle = Interpreter.next_handle
                         Interpreter.next_handle += 1
                         Interpreter.file_handles[handle] = (fobj, mode)
                         return handle
 
-                    if func_name == 'file_read':
+                    if func_name == "file_read":
                         if len(args) != 1 or not isinstance(args[0], int):
                             raise TypeError(
                                 f"file_read() expects a file handle!\n"
@@ -579,9 +615,9 @@ class Interpreter:
                             )
                         fobj, mode = entry
                         data = fobj.read()
-                        return list(data) if 'b' in mode else data
+                        return list(data) if "b" in mode else data
 
-                    if func_name == 'file_write':
+                    if func_name == "file_write":
                         if len(args) != 2 or not isinstance(args[0], int):
                             raise TypeError(
                                 f"file_write() expects handle and data!\n"
@@ -595,7 +631,7 @@ class Interpreter:
                             )
                         fobj, mode = entry
                         data = args[1]
-                        if 'b' in mode:
+                        if "b" in mode:
                             if not isinstance(data, list) or any(
                                 not isinstance(b, int) or b < 0 or b > 255 for b in data
                             ):
@@ -613,7 +649,7 @@ class Interpreter:
                         fobj.write(data)
                         return len(data.encode("utf-8"))
 
-                    if func_name == 'file_close':
+                    if func_name == "file_close":
                         if len(args) != 1 or not isinstance(args[0], int):
                             raise TypeError(
                                 f"file_close() expects a file handle!\n"
@@ -629,7 +665,7 @@ class Interpreter:
                         fobj.close()
                         return None
 
-                    if func_name == 'file_exists':
+                    if func_name == "file_exists":
                         if len(args) != 1 or not isinstance(args[0], str):
                             raise TypeError(
                                 f"file_exists() expects a path string!\n"
@@ -638,7 +674,47 @@ class Interpreter:
                         path = self._resolve_path(args[0])
                         return path.exists()
 
-                    if func_name == 'freeze':
+                    if func_name == "_omg_vm_syntax_error_handle":
+                        if len(args) != 1 or not isinstance(args[0], str):
+                            raise TypeError(
+                                f"_omg_vm_syntax_error_handle() expects a message!\n"
+                                f"on line {line} in {self.file}"
+                            )
+                        raise SyntaxError(args[0])
+
+                    if func_name == "_omg_vm_type_error_handle":
+                        if len(args) != 1 or not isinstance(args[0], str):
+                            raise TypeError(
+                                f"_omg_vm_type_error_handle() expects a message!\n"
+                                f"on line {line} in {self.file}"
+                            )
+                        raise TypeError(args[0])
+
+                    if func_name == "_omg_vm_undef_ident_error_handle":
+                        if len(args) != 1 or not isinstance(args[0], str):
+                            raise TypeError(
+                                f"_omg_vm_undef_ident_error_handle() expects a message!\n"
+                                f"on line {line} in {self.file}"
+                            )
+                        raise NameError(args[0])
+
+                    if func_name == "_omg_vm_value_error_handle":
+                        if len(args) != 1 or not isinstance(args[0], str):
+                            raise TypeError(
+                                f"_omg_vm_value_error_handle() expects a message!\n"
+                                f"on line {line} in {self.file}"
+                            )
+                        raise ValueError(args[0])
+
+                    if func_name == "_omg_vm_module_import_error_handle":
+                        if len(args) != 1 or not isinstance(args[0], str):
+                            raise TypeError(
+                                f"_omg_vm_module_import_error_handle() expects a message!\n"
+                                f"on line {line} in {self.file}"
+                            )
+                        raise ImportError(args[0])
+
+                    if func_name == "freeze":
                         if len(args) != 1 or not isinstance(args[0], dict):
                             raise TypeError(
                                 f"freeze() expects a dict!\n"
@@ -710,12 +786,12 @@ class Interpreter:
             kind = stmt[0]
             line = stmt[-1]
 
-            if kind == 'decl':
+            if kind == "decl":
                 _, var_name, expr_node, _ = stmt
                 value = self.eval_expr(expr_node)
                 self.vars[var_name] = value
 
-            elif kind == 'assign':
+            elif kind == "assign":
                 _, var_name, expr_node, _ = stmt
                 value = self.eval_expr(expr_node)
                 if var_name in self.vars:
@@ -724,7 +800,7 @@ class Interpreter:
                     self.global_vars[var_name] = value
                 else:
                     raise UndefinedVariableException(var_name, line, self.file)
-            elif kind == 'attr_assign':
+            elif kind == "attr_assign":
                 _, obj_expr, attr_name, value_expr, _ = stmt
                 target = self.eval_expr(obj_expr)
                 if not isinstance(target, dict):
@@ -733,7 +809,7 @@ class Interpreter:
                         f"On line {line} in {self.file}"
                     )
                 target[attr_name] = self.eval_expr(value_expr)
-            elif kind == 'index_assign':
+            elif kind == "index_assign":
                 _, obj_expr, key_expr, value_expr, _ = stmt
                 target = self.eval_expr(obj_expr)
                 key = self.eval_expr(key_expr)
@@ -755,17 +831,17 @@ class Interpreter:
                         f"{self._format_expr(obj_expr)} is not indexable on line {line} in {self.file}"
                     )
 
-            elif kind == 'import':
+            elif kind == "import":
                 _, path, alias, _ = stmt
                 module_ns = self.import_module(path)
                 self.vars[alias] = module_ns
 
-            elif kind == 'emit':
+            elif kind == "emit":
                 _, expr_node, _ = stmt
                 value = self.eval_expr(expr_node)
                 print(value)
 
-            elif kind == 'facts':
+            elif kind == "facts":
                 _, expr_node, line = stmt
                 value = self.eval_expr(expr_node)
                 if not value:
@@ -773,18 +849,18 @@ class Interpreter:
                         f"Assertion failed on line {line}: {self._format_expr(expr_node)}"
                     )
 
-            elif kind == 'if':
+            elif kind == "if":
                 _, cond_node, then_block, else_block, _ = stmt
                 if self.eval_expr(cond_node):
                     self.execute([then_block])
                 elif else_block:
                     self.execute([else_block])
 
-            elif kind == 'block':
+            elif kind == "block":
                 _, block_statements, _ = stmt
                 self.execute(block_statements)
 
-            elif kind == 'loop':
+            elif kind == "loop":
                 _, cond_node, block_node, _ = stmt
                 try:
                     while self.eval_expr(cond_node):
@@ -795,7 +871,7 @@ class Interpreter:
                 except BreakLoop:
                     pass
 
-            elif kind == 'try':
+            elif kind == "try":
                 _, try_block, err_name, except_block, _ = stmt
                 try:
                     self.execute([try_block])
@@ -807,10 +883,10 @@ class Interpreter:
                     if err_name:
                         self.vars[err_name] = str(e)
                     self.execute([except_block])
-            elif kind == 'break':
+            elif kind == "break":
                 raise BreakLoop()
 
-            elif kind == 'func_def':
+            elif kind == "func_def":
                 _, name, params, body, _ = stmt
                 captured = {} if self.vars is self.global_vars else self.vars.copy()
                 # Preserve the global namespace where the function was defined so that
@@ -818,12 +894,12 @@ class Interpreter:
                 func_value = FunctionValue(params, body, captured, self.global_vars)
                 self.vars[name] = func_value
 
-            elif kind == 'return':
+            elif kind == "return":
                 _, expr_node, _ = stmt
                 value = self.eval_expr(expr_node)
                 raise ReturnControlFlow(value)
 
-            elif kind == 'expr_stmt':
+            elif kind == "expr_stmt":
                 _, expr_node, _ = stmt
                 self.eval_expr(expr_node)
 

--- a/omglang/tests/test_bootstrap_compiler_bytecode.py
+++ b/omglang/tests/test_bootstrap_compiler_bytecode.py
@@ -1,0 +1,22 @@
+"""Ensure bootstrap compiler matches Python serializer."""
+from pathlib import Path
+import subprocess
+import sys
+
+from omglang.compiler import compile_source
+
+
+def test_bootstrap_compiler_matches_python(tmp_path):
+    src = 'emit 1 + 2'
+    src_path = tmp_path / 'prog.omg'
+    src_path.write_text(src, encoding='utf-8')
+    out_path = tmp_path / 'prog.omgb'
+
+    root = Path(__file__).resolve().parents[2]
+    compiler = root / 'bootstrap' / 'compiler.omg'
+    runner = root / 'omg.py'
+    subprocess.check_call([sys.executable, str(runner), str(compiler), str(src_path), str(out_path)])
+
+    data_boot = out_path.read_bytes()
+    data_py = compile_source(src, str(src_path))
+    assert data_boot == data_py

--- a/omglang/tests/test_builtin_bytecode.py
+++ b/omglang/tests/test_builtin_bytecode.py
@@ -1,4 +1,5 @@
 """Tests for builtin function compilation to bytecode."""
+
 import pytest
 
 from omglang.compiler import compile_source, disassemble
@@ -9,16 +10,17 @@ from omglang.compiler import compile_source, disassemble
     [
         ("emit length([1])", "BUILTIN length 1"),
         ("emit chr(65)", "BUILTIN chr 1"),
-        ("emit ascii(\"A\")", "BUILTIN ascii 1"),
+        ('emit ascii("A")', "BUILTIN ascii 1"),
         ("emit hex(255)", "BUILTIN hex 1"),
         ("emit binary(5)", "BUILTIN binary 1"),
         ("emit binary(5, 3)", "BUILTIN binary 2"),
-        ("emit read_file(\"README.MD\")", "BUILTIN read_file 1"),
-        ("emit file_open(\"README.MD\", \"r\")", "BUILTIN file_open 2"),
+        ('emit read_file("README.MD")', "BUILTIN read_file 1"),
+        ('emit write_file("out.omgb", "data")', "BUILTIN write_file 2"),
+        ('emit file_open("README.MD", "r")', "BUILTIN file_open 2"),
         ("emit file_read(0)", "BUILTIN file_read 1"),
-        ("emit file_write(0, \"x\")", "BUILTIN file_write 2"),
+        ('emit file_write(0, "x")', "BUILTIN file_write 2"),
         ("emit file_close(0)", "BUILTIN file_close 1"),
-        ("emit file_exists(\"README.MD\")", "BUILTIN file_exists 1"),
+        ('emit file_exists("README.MD")', "BUILTIN file_exists 1"),
     ],
 )
 def test_builtin_emits_builtin_instruction(src: str, expected: str) -> None:


### PR DESCRIPTION
## Summary
- add opcode and error mapping constants to bootstrap compiler
- expose opcode helper for future emission

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a26036e1f08323bea410482e61168c