### PR TITLE
Add bytecode emission helpers to bootstrap compiler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 Ordered from most recent at the top to oldest at the bottom.
 
+## [0.1.4] - 2025-08-11
+
+### Added
+- Bytecode emission utilities and function tracking structures in the bootstrap compiler.
+
 ## [0.1.3] - 2025-08-11
 
 ### Added

--- a/bootstrap/compiler.omg
+++ b/bootstrap/compiler.omg
@@ -134,3 +134,38 @@ alloc ERROR_NAME_TO_KIND := {
 proc opcode(name) {
     return OPCODES[name]
 }
+
+# Current instruction stream as a list of [op, arg] pairs.
+alloc code := []
+
+# Pending function bodies waiting to be appended.
+alloc pending_funcs := []
+
+# Finalized function metadata entries.
+alloc funcs := []
+
+# Stack of lists used to patch `break` statements.
+alloc break_stack := []
+
+# Create a FunctionEntry record.
+proc make_function_entry(name, params, address) {
+    return { name: name, params: params, address: address }
+}
+
+# Emit a bytecode instruction.
+proc emit(op, arg) {
+    code := code + [[op, arg]]
+}
+
+# Emit a placeholder instruction and return its index for later patching.
+proc emit_placeholder(op) {
+    alloc idx := length(code)
+    code := code + [[op, false]]
+    return idx
+}
+
+# Patch a previously emitted placeholder with the given target.
+proc patch(idx, target) {
+    alloc entry := code[idx]
+    code[idx] := [entry[0], target]
+}


### PR DESCRIPTION
## Summary
- Add FunctionEntry record and bytecode emission helper procedures in `bootstrap/compiler.omg`
- Track pending and finalized functions plus loop break patch lists
- Document change in `CHANGELOG`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a261d85988832392fd6894f55e3a03